### PR TITLE
proposal to fix #13 by always returning a js date

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -77,7 +77,12 @@ exports.DATE = function (year, month, day) {
     result = error.num;
 
   } else {
-    result = new Date(year, month - 1, day);
+    // Need to use UTC, else the date will be
+    // using whatever the local timezone of the
+    // runtime is configured to use. Leading to
+    // all sorts of unexpected behaviour as we
+    // may end up in the wrong year, month or day.
+    result = new Date(Date.UTC(year, month - 1, day));
   }
 
   return result;
@@ -162,7 +167,7 @@ exports.DATEVALUE = function (date_text) {
     modifier = 1;
   }
 
-  return Math.ceil((date - d1900) / 86400000) + modifier;
+  return utils.parseDate(Math.ceil((date - d1900) / 86400000) + modifier);
 };
 
 exports.DAY = function (serial_number) {
@@ -241,7 +246,7 @@ exports.EDATE = function (start_date, months) {
   months = parseInt(months, 10);
   start_date.setMonth(start_date.getMonth() + months);
 
-  return serial(start_date);
+  return start_date;
 };
 
 exports.EOMONTH = function (start_date, months) {
@@ -255,7 +260,7 @@ exports.EOMONTH = function (start_date, months) {
   }
   months = parseInt(months, 10);
 
-  return serial(new Date(start_date.getFullYear(), start_date.getMonth() + months + 1, 0));
+  return new Date(Date.UTC(start_date.getFullYear(), start_date.getMonth() + months + 1, 0));
 };
 
 exports.HOUR = function (serial_number) {
@@ -615,6 +620,21 @@ exports.YEARFRAC = function (start_date, end_date, basis) {
       return ((ed + em * 30 + ey * 360) - (sd + sm * 30 + sy * 360)) / 360;
   }
 };
+
+exports.SERIAL_TO_DATE = function (serial) {
+  return utils.parseDate(serial);
+}
+
+exports.DATE_TO_SERIAL = function (date) {
+
+  if (date instanceof Date) {
+    return serial(date);
+  }
+
+  return error.value;
+
+}
+
 
 function serial(date) {
   var addOn = (date > -2203891200000) ? 2 : 1;

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -169,6 +169,14 @@ exports.parseDate = function(date) {
     return new Date(d1900.getTime() + (d - 2) * 86400000);
   }
   if (typeof date === 'string') {
+    // new Date(string) implicitly calls Date.parse() which
+    // in turn will use the local timezone if the supplied
+    // string does not provide a timezone indication. Thus we
+    // may be generating more or less wrong dates here, as
+    // we are using UTC based dates for other forms of
+    // serialization (see above: parseDate from a number).
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
+    // TODO: evaluate replacing with a sane date-time library like date-fns, moment.js, ...
     date = new Date(date);
     if (!isNaN(date)) {
       return date;

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -1,7 +1,25 @@
 /* global suite, test */
 var error = require('../lib/utils/error');
 var dateTime = require('../lib/date-time');
-require('should');
+var should = require('should');
+
+/**
+ * Custom assertion to test for equal js date object
+ * @see: https://github.com/shouldjs/should.js#adding-own-assertions
+ */
+should.Assertion.add('equalDate', function(year, month, day) {
+
+    var expectedDate = new Date(Date.UTC(year, month, day));
+
+    this.params = {
+        operator: 'to be',
+        expected: expectedDate,
+    };
+
+    this.obj.should.be.instanceOf(Date);
+    this.obj.getTime().should.be.equal(expectedDate.getTime());
+
+});
 
 describe('Date & Time', function () {
   it('DATE', function () {
@@ -37,8 +55,12 @@ describe('Date & Time', function () {
   });
 
   it('DATEVALUE', function () {
-    dateTime.DATEVALUE('1/1/1900').should.equal(1);
-    dateTime.DATEVALUE('12/31/9999').should.equal(2958465);
+    //dateTime.DATEVALUE('1/1/1900').should.equal(1);
+    //dateTime.DATEVALUE('12/31/9999').should.equal(2958465);
+    //dateTime.DATEVALUE('foo bar').should.equal(error.value);
+    //dateTime.DATEVALUE(1).should.equal(error.value);
+    dateTime.DATEVALUE('1/1/1900').should.equalDate(1900, 0, 1);
+    dateTime.DATEVALUE('12/31/9999').should.equalDate(9999, 11, 31);
     dateTime.DATEVALUE('foo bar').should.equal(error.value);
     dateTime.DATEVALUE(1).should.equal(error.value);
   });
@@ -77,19 +99,29 @@ describe('Date & Time', function () {
   });
 
   it('EDATE', function () {
-    dateTime.EDATE('1/1/1900', 0).should.equal(1);
-    dateTime.EDATE('1/1/1900', 1).should.equal(32);
-    dateTime.EDATE('1/1/1900', 12).should.equal(367);
+    //dateTime.EDATE('1/1/1900', 0).should.equal(1);
+    //dateTime.EDATE('1/1/1900', 1).should.equal(32);
+    //dateTime.EDATE('1/1/1900', 12).should.equal(367);
+    //dateTime.EDATE('a', 0).should.equal(error.value);
+    //dateTime.EDATE('1/1/1900', 'a').should.equal(error.value);
+    dateTime.EDATE(dateTime.DATE(1900,1,1), 0).should.equalDate(1900, 0, 1);
+    dateTime.EDATE(dateTime.DATE(1900,1,1), 1).should.equalDate(1900, 1, 1);
+    dateTime.EDATE(dateTime.DATE(1900,1,1), 12).should.equalDate(1901, 0, 1);
     dateTime.EDATE('a', 0).should.equal(error.value);
-    dateTime.EDATE('1/1/1900', 'a').should.equal(error.value);
+    dateTime.EDATE(dateTime.DATE(1900,1,1), 'a').should.equal(error.value);
   });
 
   it('EOMONTH', function () {
-    dateTime.EOMONTH('1/1/1900', 0).should.equal(31);
-    dateTime.EOMONTH('1/1/1900', 1).should.equal(59);
-    dateTime.EOMONTH('1/1/1900', 12).should.equal(397);
+    //dateTime.EOMONTH('1/1/1900', 0).should.equal(31);
+    //dateTime.EOMONTH('1/1/1900', 1).should.equal(59);
+    //dateTime.EOMONTH('1/1/1900', 12).should.equal(397);
+    //dateTime.EOMONTH('a', 0).should.equal(error.value);
+    //dateTime.EOMONTH('1/1/1900', 'a').should.equal(error.value);
+    dateTime.EOMONTH(dateTime.DATE(1900,1,1), 0).should.equalDate(1900, 0, 31);
+    dateTime.EOMONTH(dateTime.DATE(1900,1,1), 1).should.equalDate(1900, 1, 28);
+    dateTime.EOMONTH(dateTime.DATE(1900,1,1), 12).should.equalDate(1901, 0, 31);
     dateTime.EOMONTH('a', 0).should.equal(error.value);
-    dateTime.EOMONTH('1/1/1900', 'a').should.equal(error.value);
+    dateTime.EOMONTH(dateTime.DATE(1900,1,1), 'a').should.equal(error.value);
   });
 
   it('HOUR', function () {
@@ -232,4 +264,16 @@ describe('Date & Time', function () {
     dateTime.YEARFRAC('a', '1/2/1900').should.equal(error.value);
     dateTime.YEARFRAC('1/1/1900', 'a').should.equal(error.value);
   });
+
+  it('SERIAL_TO_DATE', function() {
+    dateTime.SERIAL_TO_DATE(1).should.equalDate(1900, 0, 1);
+    dateTime.SERIAL_TO_DATE('a').should.equal(error.value);
+  });
+
+  it('DATE_TO_SERIAL', function() {
+    dateTime.DATE_TO_SERIAL(new Date(Date.UTC(1900,0,1))).should.equal(1);
+    dateTime.DATE_TO_SERIAL(0).should.equal(error.value);
+    dateTime.DATE_TO_SERIAL('a').should.equal(error.value);
+  });
+
 });


### PR DESCRIPTION
# Background

Following the discussion in #13 this pr provides a first quick implementation with all date-time functions returning js-dates instead of serial numbers.

# Changes

- Changed the return type of `DATEVALUE`, `EDATE` and `EOMONTH` from serial number to js date
- also added `SERIAL_TO_DATE` and `DATE_TO_SERIAL` to allow interop with standard Excel behaviour
- changed `DATE` to always return an UTC date object instead of relying on the system timezone