### PR TITLE
Fix DAYS and ISOWEEKNUM: compare values at the start of the day

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -304,7 +304,7 @@ exports.ISOWEEKNUM = function (date) {
     return date;
   }
 
-  date.setHours(0, 0, 0);
+  date = startOfDay(date);
   date.setDate(date.getDate() + 4 - (date.getDay() || 7));
   var yearStart = new Date(date.getFullYear(), 0, 1);
 

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -167,6 +167,15 @@ exports.DAY = function (serial_number) {
   return date.getDate();
 };
 
+function startOfDay(date) {
+  var newDate = new Date(date);
+  newDate.setHours(0);
+  newDate.setMinutes(0);
+  newDate.setSeconds(0);
+  newDate.setMilliseconds(0);
+  return newDate;
+}
+
 exports.DAYS = function (end_date, start_date) {
   end_date = utils.parseDate(end_date);
   start_date = utils.parseDate(start_date);
@@ -178,7 +187,7 @@ exports.DAYS = function (end_date, start_date) {
     return start_date;
   }
 
-  return serial(end_date) - serial(start_date);
+  return serial(startOfDay(end_date)) - serial(startOfDay(start_date));
 };
 
 exports.DAYS360 = function (start_date, end_date, method) {
@@ -426,11 +435,7 @@ exports.TIMEVALUE = function (time_text) {
 };
 
 exports.TODAY = function () {
-  var today = new Date();
-  today.setHours(0);
-  today.setMinutes(0);
-  today.setSeconds(0);
-  return today;
+  return startOfDay(new Date());
 };
 
 exports.WEEKDAY = function (serial_number, return_type) {

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -169,10 +169,7 @@ exports.DAY = function (serial_number) {
 
 function startOfDay(date) {
   var newDate = new Date(date);
-  newDate.setHours(0);
-  newDate.setMinutes(0);
-  newDate.setSeconds(0);
-  newDate.setMilliseconds(0);
+  newDate.setHours(0, 0, 0, 0);
   return newDate;
 }
 

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -59,6 +59,7 @@ describe('Date & Time', function () {
     dateTime.DAYS(new Date(1900, 1, 2), new Date(1900, 1, 1)).should.equal(1);
     dateTime.DAYS('a', 1).should.equal(error.value);
     dateTime.DAYS(1, 'a').should.equal(error.value);
+    dateTime.DAYS(dateTime.NOW(), dateTime.TODAY()).should.equal(0);
   });
 
   it('DAYS360', function () {

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -59,6 +59,7 @@ describe('Date & Time', function () {
     dateTime.DAYS(new Date(1900, 1, 2), new Date(1900, 1, 1)).should.equal(1);
     dateTime.DAYS('a', 1).should.equal(error.value);
     dateTime.DAYS(1, 'a').should.equal(error.value);
+    dateTime.DAYS('1/1/1900 00:20', '1/1/1900 01:30').should.equal(0);
     dateTime.DAYS(dateTime.NOW(), dateTime.TODAY()).should.equal(0);
   });
 

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -111,6 +111,7 @@ describe('Date & Time', function () {
     dateTime.ISOWEEKNUM('12/29/1901').should.equal(52);
     dateTime.ISOWEEKNUM('6/6/1902').should.equal(23);
     dateTime.ISOWEEKNUM('a').should.equal(error.value);
+    dateTime.ISOWEEKNUM(new Date('2021-02-04T00:00:00.123Z')).should.equal(5);
   });
 
   it('MINUTE', function () {


### PR DESCRIPTION
This fixes what I consider to be an edge case with DAYS function. Even if given Date objects are a few hours apart, if they are on the same date, the difference should be 0. This is achieved by moving both end date and start date objects to start of the day. 

The example provided in the test:
1/1/1900 01:30 and 1/1/1900 00:20 are on same day and the result should not be 1 but 0.

Similar thing occurs for ISOWEEKNUM, it jumps by 1 if there are some milliseconds left on the Date object.

Cheers!