### PR TITLE
Support weekend string values in NETWORKDAYSINTL

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -359,7 +359,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
     weekend = weekend.split('');
     for (i = 0; i < weekend.length; i++) {
       if (weekend[i] == 1) {
-        maskDays.push(maskIndex[i])
+        maskDays.push(maskIndex[i]);
       }
     }
   } else {

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -346,8 +346,22 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
   if (end_date instanceof Error) {
     return end_date;
   }
+  
+  var isMask = false;
+  var maskDays = [];
+  var maskIndex = [1, 2, 3, 4, 5, 6, 0]
+  var maskRegex = new RegExp('^[0|1]{7}$');
+  
   if (weekend === undefined) {
     weekend = WEEKEND_TYPES[1];
+  } else if (typeof weekend === 'string' && maskRegex.test(weekend)) {
+    isMask = true;
+    weekend = weekend.split('');
+    for (i = 0; i < weekend.length; i++) {
+      if (weekend[i] == 1) {
+        maskDays.push(maskIndex[i])
+      }
+    }
   } else {
     weekend = WEEKEND_TYPES[weekend];
   }
@@ -372,10 +386,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
   var day = start_date;
   for (i = 0; i < days; i++) {
     var d = (new Date().getTimezoneOffset() > 0) ? day.getUTCDay() : day.getDay();
-    var dec = false;
-    if (d === weekend[0] || d === weekend[1]) {
-      dec = true;
-    }
+    var dec = isMask ? maskDays.includes(d) : (d === weekend[0] || d === weekend[1]);
     for (var j = 0; j < holidays.length; j++) {
       var holiday = holidays[j];
       if (holiday.getDate() === day.getDate() &&

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -148,6 +148,9 @@ describe('Date & Time', function () {
     dateTime.NETWORKDAYS.INTL('12/4/2013', '12/5/2013').should.equal(2);
     dateTime.NETWORKDAYS.INTL('12/8/2013', '12/9/2013', 2).should.equal(0);
     dateTime.NETWORKDAYS.INTL('12/4/2013', '12/4/2013', -1).should.equal(error.value);
+    dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', 'smlkml').should.equal(error.value);
+    dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '00011').should.equal(error.value);
+    dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '0001101').should.equal(32);
   });
 
   it('NOW', function () {


### PR DESCRIPTION
Weekend string values are seven characters long and each character in the string represents a day of the week, starting with Monday. 1 represents a non-workday and 0 represents a workday.