### PR TITLE
Improve Excel parity for undefined, null & error inputs

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -346,12 +346,12 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
   if (end_date instanceof Error) {
     return end_date;
   }
-  
+
   var isMask = false;
   var maskDays = [];
-  var maskIndex = [1, 2, 3, 4, 5, 6, 0]
+  var maskIndex = [1, 2, 3, 4, 5, 6, 0];
   var maskRegex = new RegExp('^[0|1]{7}$');
-  
+
   if (weekend === undefined) {
     weekend = WEEKEND_TYPES[1];
   } else if (typeof weekend === 'string' && maskRegex.test(weekend)) {

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -4,9 +4,16 @@ var information = require('./information');
 
 exports.AND = function() {
   var args = utils.flatten(arguments);
+  if (args.every(function (arg) { return arg === undefined || arg === null; })) {
+    return error.value;
+  }
+  var someError = args.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
   var result = true;
   for (var i = 0; i < args.length; i++) {
-    if (!args[i]) {
+    if (args[i] === false) {
       result = false;
     }
   }
@@ -35,8 +42,17 @@ exports.FALSE = function() {
 };
 
 exports.IF = function(test, then_value, otherwise_value) {
+  if (test instanceof Error) {
+    return test;
+  }
   then_value = arguments.length >= 2 ? then_value : true;
-  otherwise_value = arguments.length === 3 ? otherwise_value : false
+  if (then_value === undefined || then_value === null) {
+    then_value = 0;
+  }
+  otherwise_value = arguments.length === 3 ? otherwise_value : false;
+  if (otherwise_value === undefined || otherwise_value === null) {
+    otherwise_value = 0;
+  }
   return test ? then_value : otherwise_value;
 };
 
@@ -66,6 +82,13 @@ exports.NOT = function(logical) {
 
 exports.OR = function() {
   var args = utils.flatten(arguments);
+  if (args.every(function (arg) { return arg === undefined || arg === null; })) {
+    return error.value;
+  }
+  var someError = args.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
   var result = false;
   for (var i = 0; i < args.length; i++) {
     if (args[i]) {

--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -5,6 +5,9 @@ var information = require('./information');
 var evalExpression = require('./utils/criteria-eval');
 
 exports.ABS = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -15,6 +18,9 @@ exports.ABS = function(number) {
 };
 
 exports.ACOS = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -29,6 +35,9 @@ exports.ACOS = function(number) {
 };
 
 exports.ACOSH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -43,6 +52,9 @@ exports.ACOSH = function(number) {
 };
 
 exports.ACOT = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -53,6 +65,9 @@ exports.ACOT = function(number) {
 };
 
 exports.ACOTH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -116,6 +131,12 @@ exports.AGGREGATE = function(function_num, options, ref1, ref2) {
 };
 
 exports.ARABIC = function(text) {
+  if (text === undefined || text === null) {
+    return 0;
+  }
+  if (text instanceof Error) {
+    return text;
+  }
   // Credits: Rafa? Kukawski
   if (!/^M*(?:D?C{0,3}|C[MD])(?:L?X{0,3}|X[CL])(?:V?I{0,3}|I[XV])$/.test(text)) {
     return error.value;
@@ -142,6 +163,9 @@ exports.ARABIC = function(text) {
 };
 
 exports.ASIN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -156,6 +180,9 @@ exports.ASIN = function(number) {
 };
 
 exports.ASINH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -164,6 +191,9 @@ exports.ASINH = function(number) {
 };
 
 exports.ATAN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -172,6 +202,12 @@ exports.ATAN = function(number) {
 };
 
 exports.ATAN2 = function(number_x, number_y) {
+  if (number_x instanceof Error) {
+    return number_x;
+  }
+  if (number_y instanceof Error) {
+    return number_y;
+  }
   number_x = utils.parseNumber(number_x);
   number_y = utils.parseNumber(number_y);
   if (utils.anyIsError(number_x, number_y)) {
@@ -181,6 +217,9 @@ exports.ATAN2 = function(number_x, number_y) {
 };
 
 exports.ATANH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -195,6 +234,15 @@ exports.ATANH = function(number) {
 };
 
 exports.BASE = function(number, radix, min_length) {
+  if (radix instanceof Error) {
+    return radix;
+  }
+  if (number instanceof Error) {
+    return number;
+  }
+  if (radix === undefined || radix === null) {
+    return error.num;
+  }
   min_length = min_length || 0;
 
   number = utils.parseNumber(number);
@@ -209,6 +257,15 @@ exports.BASE = function(number, radix, min_length) {
 };
 
 exports.CEILING = function(number, significance, mode) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (significance instanceof Error) {
+    return significance;
+  }
+  if (mode instanceof Error) {
+    return mode;
+  }
   significance = (significance === undefined) ? 1 : Math.abs(significance);
   mode = mode || 0;
 
@@ -238,24 +295,45 @@ exports.CEILING.MATH = exports.CEILING;
 exports.CEILING.PRECISE = exports.CEILING;
 
 exports.COMBIN = function(number, number_chosen) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (number_chosen instanceof Error) {
+    return number_chosen;
+  }
   number = utils.parseNumber(number);
   number_chosen = utils.parseNumber(number_chosen);
   if (utils.anyIsError(number, number_chosen)) {
     return error.value;
+  }
+  if (number < number_chosen) {
+    return error.num;
   }
   return exports.FACT(number) / (exports.FACT(number_chosen) * exports.FACT(number - number_chosen));
 };
 
 exports.COMBINA = function(number, number_chosen) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (number_chosen instanceof Error) {
+    return number_chosen;
+  }
   number = utils.parseNumber(number);
   number_chosen = utils.parseNumber(number_chosen);
   if (utils.anyIsError(number, number_chosen)) {
     return error.value;
   }
+  if (number < number_chosen) {
+    return error.num;
+  }
   return (number === 0 && number_chosen === 0) ? 1 : exports.COMBIN(number + number_chosen - 1, number - 1);
 };
 
 exports.COS = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -264,6 +342,9 @@ exports.COS = function(number) {
 };
 
 exports.COSH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -272,34 +353,58 @@ exports.COSH = function(number) {
 };
 
 exports.COT = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
+  }
+  if (number === 0) {
+    return error.div0;
   }
   return 1 / Math.tan(number);
 };
 
 exports.COTH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
+  }
+  if (number === 0) {
+    return error.div0;
   }
   var e2 = Math.exp(2 * number);
   return (e2 + 1) / (e2 - 1);
 };
 
 exports.CSC = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
+  }
+  if (number === 0) {
+    return error.div0;
   }
   return 1 / Math.sin(number);
 };
 
 exports.CSCH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
+  }
+  if (number === 0) {
+    return error.div0;
   }
   return 2 / (Math.exp(number) - Math.exp(-number));
 };
@@ -308,11 +413,26 @@ exports.DECIMAL = function(number, radix) {
   if (arguments.length < 1) {
     return error.value;
   }
+  if (number instanceof Error) {
+    return number;
+  }
+  if (radix instanceof Error) {
+    return radix;
+  }
+  if (radix === undefined || radix === null) {
+    return error.num;
+  }
+  if (number === undefined || number === null) {
+    return 0;
+  }
 
   return parseInt(number, radix);
 };
 
 exports.DEGREES = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -321,6 +441,9 @@ exports.DEGREES = function(number) {
 };
 
 exports.EVEN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -332,9 +455,21 @@ exports.EXP = function(number) {
   if (arguments.length < 1) {
     return error.na;
   }
-  if (typeof number !== 'number' || arguments.length > 1) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (number === null || number === undefined) {
+    return 1;
+  }
+  if (arguments.length > 1) {
     return error.error;
   }
+
+  number = utils.parseNumber(number);
+  if (number instanceof Error) {
+    return number;
+  }
+
 
   number = Math.exp(number);
 
@@ -343,6 +478,9 @@ exports.EXP = function(number) {
 
 var MEMOIZED_FACT = [];
 exports.FACT = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -359,6 +497,9 @@ exports.FACT = function(number) {
 };
 
 exports.FACTDOUBLE = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -372,6 +513,12 @@ exports.FACTDOUBLE = function(number) {
 };
 
 exports.FLOOR = function(number, significance) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (significance instanceof Error) {
+    return significance;
+  }
   number = utils.parseNumber(number);
   significance = utils.parseNumber(significance);
   if (utils.anyIsError(number, significance)) {
@@ -381,7 +528,7 @@ exports.FLOOR = function(number, significance) {
     return 0;
   }
 
-  if (!(number > 0 && significance > 0) && !(number < 0 && significance < 0)) {
+  if (!(number >= 0 && significance > 0) && !(number <= 0 && significance < 0)) {
     return error.num;
   }
 
@@ -396,7 +543,16 @@ exports.FLOOR = function(number, significance) {
 
 //TODO: Verify
 exports.FLOOR.MATH = function(number, significance, mode) {
-  significance = (significance === undefined) ? 1 : significance;
+  if (number instanceof Error) {
+    return number;
+  }
+  if (significance instanceof Error) {
+    return significance;
+  }
+  if (mode instanceof Error) {
+    return mode;
+  }
+  significance = (significance === undefined) ? 0 : significance;
   mode = (mode === undefined) ? 0 : mode;
 
   number = utils.parseNumber(number);
@@ -424,7 +580,11 @@ exports.FLOOR.PRECISE = exports.FLOOR.MATH;
 
 // adapted http://rosettacode.org/wiki/Greatest_common_divisor#JavaScript
 exports.GCD = function() {
-  var range = utils.parseNumberArray(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  if (flatArguments.every(function (arg) { return arg === undefined || arg === null; })) {
+    return error.value;
+  }
+  var range = utils.parseNumberArray(flatArguments);
   if (range instanceof Error) {
     return range;
   }
@@ -448,6 +608,9 @@ exports.GCD = function() {
 
 
 exports.INT = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -461,8 +624,13 @@ exports.ISO = {
 };
 
 exports.LCM = function() {
+  var flatArguments = utils.flatten(arguments);
+  if (flatArguments.every(function (arg) { return arg === undefined || arg === null; })) {
+    return error.value;
+  }
+
   // Credits: Jonas Raoni Soares Silva
-  var o = utils.parseNumberArray(utils.flatten(arguments));
+  var o = utils.parseNumberArray(flatArguments);
   if (o instanceof Error) {
     return o;
   }
@@ -487,6 +655,12 @@ exports.LCM = function() {
 };
 
 exports.LN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (number === undefined || number === null) {
+    return error.num;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -511,6 +685,15 @@ exports.LOG2E = function() {
 };
 
 exports.LOG = function(number, base) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (base instanceof Error) {
+    return base;
+  }
+  if (number === undefined || number === null || base === undefined || base === null) {
+    return error.num;
+  }
   number = utils.parseNumber(number);
   base = base ? utils.parseNumber(base) : 10;
   if (utils.anyIsError(number, base)) {
@@ -521,6 +704,12 @@ exports.LOG = function(number, base) {
 };
 
 exports.LOG10 = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (number === undefined || number === null) {
+    return error.num;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -529,6 +718,12 @@ exports.LOG10 = function(number) {
 };
 
 exports.MOD = function(dividend, divisor) {
+  if (dividend instanceof Error) {
+    return dividend;
+  }
+  if (divisor instanceof Error) {
+    return divisor;
+  }
   dividend = utils.parseNumber(dividend);
   divisor = utils.parseNumber(divisor);
   if (utils.anyIsError(dividend, divisor)) {
@@ -543,6 +738,15 @@ exports.MOD = function(dividend, divisor) {
 };
 
 exports.MROUND = function(number, multiple) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (multiple instanceof Error) {
+    return multiple;
+  }
+  if (number === undefined || number === null || multiple === undefined || multiple === null) {
+    return 0;
+  }
   number = utils.parseNumber(number);
   multiple = utils.parseNumber(multiple);
   if (utils.anyIsError(number, multiple)) {
@@ -556,7 +760,11 @@ exports.MROUND = function(number, multiple) {
 };
 
 exports.MULTINOMIAL = function() {
-  var args = utils.parseNumberArray(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  if (flatArguments.every(function (arg) { return arg === undefined || arg === null; })) {
+    return error.value;
+  }
+  var args = utils.parseNumberArray(flatArguments);
   if (args instanceof Error) {
     return args;
   }
@@ -570,13 +778,16 @@ exports.MULTINOMIAL = function() {
 };
 
 exports.ODD = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
   }
   var temp = Math.ceil(Math.abs(number));
   temp = (temp & 1) ? temp : temp + 1;
-  return (number > 0) ? temp : -temp;
+  return (number >= 0) ? temp : -temp;
 };
 
 exports.PI = function() {
@@ -588,6 +799,15 @@ exports.E = function() {
 };
 
 exports.POWER = function(number, power) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (power instanceof Error) {
+    return power;
+  }
+  if ((number === undefined || number === null) && (power === undefined || power === null)) {
+    return error.num;
+  }
   number = utils.parseNumber(number);
   power = utils.parseNumber(power);
   if (utils.anyIsError(number, power)) {
@@ -602,7 +822,12 @@ exports.POWER = function(number, power) {
 };
 
 exports.PRODUCT = function() {
-  var args = utils.parseNumberArray(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(function (arg) { return arg !== undefined && arg !== null; });
+  if (flatArgumentsDefined.length === 0) {
+    return 0;
+  }
+  var args = utils.parseNumberArray(flatArgumentsDefined);
   if (args instanceof Error) {
     return args;
   }
@@ -664,6 +889,12 @@ exports.ROMAN = function(number) {
 };
 
 exports.ROUND = function(number, digits) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (digits instanceof Error) {
+    return digits;
+  }
   number = utils.parseNumber(number);
   digits = utils.parseNumber(digits);
   if (utils.anyIsError(number, digits)) {
@@ -673,6 +904,12 @@ exports.ROUND = function(number, digits) {
 };
 
 exports.ROUNDDOWN = function(number, digits) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (digits instanceof Error) {
+    return digits;
+  }
   number = utils.parseNumber(number);
   digits = utils.parseNumber(digits);
   if (utils.anyIsError(number, digits)) {
@@ -683,6 +920,12 @@ exports.ROUNDDOWN = function(number, digits) {
 };
 
 exports.ROUNDUP = function(number, digits) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (digits instanceof Error) {
+    return digits;
+  }
   number = utils.parseNumber(number);
   digits = utils.parseNumber(digits);
   if (utils.anyIsError(number, digits)) {
@@ -693,6 +936,9 @@ exports.ROUNDUP = function(number, digits) {
 };
 
 exports.SEC = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -701,6 +947,9 @@ exports.SEC = function(number) {
 };
 
 exports.SECH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -724,6 +973,9 @@ exports.SERIESSUM = function(x, n, m, coefficients) {
 };
 
 exports.SIGN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -738,6 +990,9 @@ exports.SIGN = function(number) {
 };
 
 exports.SIN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -746,6 +1001,9 @@ exports.SIN = function(number) {
 };
 
 exports.SINH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -754,6 +1012,9 @@ exports.SINH = function(number) {
 };
 
 exports.SQRT = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -765,6 +1026,9 @@ exports.SQRT = function(number) {
 };
 
 exports.SQRTPI = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -839,6 +1103,12 @@ exports.ADD = function (num1, num2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (num1 instanceof Error) {
+    return num1;
+  }
+  if (num2 instanceof Error) {
+    return num2;
+  }
 
   num1 = utils.parseNumber(num1);
   num2 = utils.parseNumber(num2);
@@ -853,6 +1123,12 @@ exports.MINUS = function (num1, num2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (num1 instanceof Error) {
+    return num1;
+  }
+  if (num2 instanceof Error) {
+    return num2;
+  }
 
   num1 = utils.parseNumber(num1);
   num2 = utils.parseNumber(num2);
@@ -866,6 +1142,12 @@ exports.MINUS = function (num1, num2) {
 exports.DIVIDE = function (dividend, divisor) {
   if (arguments.length !== 2) {
     return error.na;
+  }
+  if (dividend instanceof Error) {
+    return dividend;
+  }
+  if (divisor instanceof Error) {
+    return divisor;
   }
 
   dividend = utils.parseNumber(dividend);
@@ -885,6 +1167,12 @@ exports.MULTIPLY = function (factor1, factor2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (factor1 instanceof Error) {
+    return factor1;
+  }
+  if (factor2 instanceof Error) {
+    return factor2;
+  }
 
   factor1 = utils.parseNumber(factor1);
   factor2 = utils.parseNumber(factor2);
@@ -899,6 +1187,12 @@ exports.GTE = function (num1, num2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (num1 instanceof Error) {
+    return num1;
+  }
+  if (num2 instanceof Error) {
+    return num2;
+  }
 
   num1 = utils.parseNumber(num1);
   num2 = utils.parseNumber(num2);
@@ -912,6 +1206,12 @@ exports.GTE = function (num1, num2) {
 exports.LT = function (num1, num2) {
   if (arguments.length !== 2) {
     return error.na;
+  }
+  if (num1 instanceof Error) {
+    return num1;
+  }
+  if (num2 instanceof Error) {
+    return num2;
   }
 
   num1 = utils.parseNumber(num1);
@@ -928,6 +1228,12 @@ exports.LTE = function (num1, num2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (num1 instanceof Error) {
+    return num1;
+  }
+  if (num2 instanceof Error) {
+    return num2;
+  }
 
   num1 = utils.parseNumber(num1);
   num2 = utils.parseNumber(num2);
@@ -942,6 +1248,18 @@ exports.EQ = function (value1, value2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (value1 instanceof Error) {
+    return value1;
+  }
+  if (value2 instanceof Error) {
+    return value2;
+  }
+  if (value1 === null) {
+    value1 = undefined;
+  }
+  if (value2 === null) {
+    value2 = undefined;
+  }
 
   return value1 === value2;
 };
@@ -949,6 +1267,18 @@ exports.EQ = function (value1, value2) {
 exports.NE = function (value1, value2) {
   if (arguments.length !== 2) {
     return error.na;
+  }
+  if (value1 instanceof Error) {
+    return value1;
+  }
+  if (value2 instanceof Error) {
+    return value2;
+  }
+  if (value1 === null) {
+    value1 = undefined;
+  }
+  if (value2 === null) {
+    value2 = undefined;
   }
 
   return value1 !== value2;
@@ -959,12 +1289,6 @@ exports.POW = function (base, exponent) {
     return error.na;
   }
 
-  base = utils.parseNumber(base);
-  exponent = utils.parseNumber(exponent);
-  if (utils.anyIsError(base, exponent)) {
-    return error.error;
-  }
-
   return exports.POWER(base, exponent);
 };
 
@@ -972,6 +1296,12 @@ exports.SUM = function() {
   var result = 0;
 
   utils.arrayEach(utils.argsToArray(arguments), function(value) {
+    if (result instanceof Error) {
+      return;
+    }
+    if (value instanceof Error) {
+      result = value;
+    }
     if (typeof value === 'number') {
       result += value;
 
@@ -998,8 +1328,11 @@ exports.SUMIF = function (range, criteria, sumRange) {
   if (range instanceof Error) {
     return range;
   }
+  if (criteria === undefined || criteria === null || criteria instanceof Error) {
+    return 0;
+  }
   var result = 0;
-  var isWildcard = criteria === void 0 || criteria === '*';
+  var isWildcard = criteria === '*';
   var tokenizedCriteria = isWildcard ? null : evalExpression.parse(criteria + '');
   for (var i = 0; i < range.length; i++) {
     var value = range[i];
@@ -1010,7 +1343,7 @@ exports.SUMIF = function (range, criteria, sumRange) {
     } else {
       var tokens = [evalExpression.createToken(value, evalExpression.TOKEN_TYPE_LITERAL)].concat(tokenizedCriteria);
 
-      result += (evalExpression.compute(tokens) ? sumValue : 0);
+      result += evalExpression.compute(tokens) ? sumValue : 0;
     }
   }
 
@@ -1083,7 +1416,11 @@ exports.SUMPRODUCT = function() {
     if (!(arguments[0][i] instanceof Array)) {
       product = 1;
       for (k = 1; k < arrays; k++) {
-        _i = utils.parseNumber(arguments[k - 1][i]);
+        var _i_arg = arguments[k - 1][i];
+        if (_i_arg instanceof Error) {
+          return _i_arg;
+        }
+        _i = utils.parseNumber(_i_arg);
         if (_i instanceof Error) {
           return _i;
         }
@@ -1094,7 +1431,11 @@ exports.SUMPRODUCT = function() {
       for (var j = 0; j < arguments[0][i].length; j++) {
         product = 1;
         for (k = 1; k < arrays; k++) {
-          _ij = utils.parseNumber(arguments[k - 1][i][j]);
+          var _ij_arg = arguments[k - 1][i][j];
+          if (_ij_arg instanceof Error) {
+            return _ij_arg;
+          }
+          _ij = utils.parseNumber(_ij_arg);
           if (_ij instanceof Error) {
             return _ij;
           }
@@ -1164,6 +1505,9 @@ exports.SUMXMY2 = function(array_x, array_y) {
 };
 
 exports.TAN = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -1172,6 +1516,9 @@ exports.TAN = function(number) {
 };
 
 exports.TANH = function(number) {
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -1181,6 +1528,12 @@ exports.TANH = function(number) {
 };
 
 exports.TRUNC = function(number, digits) {
+  if (number instanceof Error) {
+    return number;
+  }
+  if (digits instanceof Error) {
+    return digits;
+  }
   digits = (digits === undefined) ? 0 : digits;
   number = utils.parseNumber(number);
   digits = utils.parseNumber(digits);

--- a/lib/statistical.js
+++ b/lib/statistical.js
@@ -9,7 +9,12 @@ var misc = require('./miscellaneous');
 var SQRT2PI = 2.5066282746310002;
 
 exports.AVEDEV = function() {
-  var range = utils.parseNumberArray(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(function (arg) { return arg !== undefined && arg !== null; });
+  if (flatArgumentsDefined.length === 0) {
+    return error.num;
+  }
+  var range = utils.parseNumberArray(flatArgumentsDefined);
   if (range instanceof Error) {
     return range;
   }
@@ -17,7 +22,16 @@ exports.AVEDEV = function() {
 };
 
 exports.AVERAGE = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(function (arg) { return arg !== undefined && arg !== null; });
+  if (flatArgumentsDefined.length === 0) {
+    return error.div0;
+  }
+  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArgumentsDefined);
   var n = range.length;
   var sum = 0;
   var count = 0;
@@ -37,7 +51,16 @@ exports.AVERAGE = function() {
 };
 
 exports.AVERAGEA = function() {
-  var range = utils.flatten(arguments);
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(function (arg) { return arg !== undefined && arg !== null; });
+  if (flatArgumentsDefined.length === 0) {
+    return error.div0;
+  }
+  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = flatArgumentsDefined;
   var n = range.length;
   var sum = 0;
   var count = 0;
@@ -68,8 +91,11 @@ exports.AVERAGEIF = function(range, criteria, average_range) {
     return error.na;
   }
   average_range = average_range || range;
+  var flatAverageRange = utils.flatten(average_range);
+  var flatAverageRangeDefined = flatAverageRange.filter(function (arg) { return arg !== undefined && arg !== null; });
+  average_range = utils.parseNumberArray(flatAverageRangeDefined);
+
   range = utils.flatten(range);
-  average_range = utils.parseNumberArray(utils.flatten(average_range));
 
   if (average_range instanceof Error) {
     return average_range;
@@ -100,7 +126,7 @@ exports.AVERAGEIF = function(range, criteria, average_range) {
 
 exports.AVERAGEIFS = function() {
   // Does not work with multi dimensional ranges yet!
-  //http://office.microsoft.com/en-001/excel-help/averageifs-function-HA010047493.aspx
+  // http://office.microsoft.com/en-001/excel-help/averageifs-function-HA010047493.aspx
   var args = utils.argsToArray(arguments);
   var criteriaLength = (args.length - 1) / 2;
   var range = utils.flatten(args[0]);
@@ -427,12 +453,21 @@ exports.CORREL = function(array1, array2) {
 };
 
 exports.COUNT = function() {
-  return utils.numbers(utils.flatten(arguments)).length;
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  return utils.numbers(flatArguments).length;
 };
 
 exports.COUNTA = function() {
-  var range = utils.flatten(arguments);
-  return range.length - exports.COUNTBLANK(range);
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  return flatArguments.length - exports.COUNTBLANK(flatArguments);
 };
 
 exports.COUNTIN = function (range, value) {
@@ -451,11 +486,15 @@ exports.COUNTIN = function (range, value) {
 
 exports.COUNTBLANK = function() {
   var range = utils.flatten(arguments);
+  var someError = range.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
   var blanks = 0;
   var element;
   for (var i = 0; i < range.length; i++) {
     element = range[i];
-    if (element === null || element === '') {
+    if (element === undefined || element === null || element === '') {
       blanks++;
     }
   }
@@ -464,6 +503,10 @@ exports.COUNTBLANK = function() {
 
 exports.COUNTIF = function(range, criteria) {
   range = utils.flatten(range);
+  var someError = range.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
 
   var isWildcard = criteria === void 0 || criteria === '*';
 
@@ -495,6 +538,10 @@ exports.COUNTIFS = function() {
   }
   for (i = 0; i < args.length; i += 2) {
     var range = utils.flatten(args[i]);
+    var someError = range.find(function (arg) { return arg instanceof Error; });
+    if (someError) {
+      return someError;
+    }
     var criteria = args[i + 1];
     var isWildcard = criteria === void 0 || criteria === '*';
 
@@ -1036,17 +1083,33 @@ exports.LOGNORM.INV = function(probability, mean, sd) {
 };
 
 exports.MAX = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArguments);
   return (range.length === 0) ? 0 : Math.max.apply(Math, range);
 };
 
 exports.MAXA = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
+  range = range.map(function (value) { return (value === undefined || value === null) ? 0 : value; });
   return (range.length === 0) ? 0 : Math.max.apply(Math, range);
 };
 
 exports.MEDIAN = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
   var result = jStat.median(range);
 
   if (isNaN(result)) {
@@ -1057,12 +1120,23 @@ exports.MEDIAN = function() {
 };
 
 exports.MIN = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArguments);
   return (range.length === 0) ? 0 : Math.min.apply(Math, range);
 };
 
 exports.MINA = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
+  range = range.map(function (value) { return (value === undefined || value === null) ? 0 : value; });
   return (range.length === 0) ? 0 : Math.min.apply(Math, range);
 };
 

--- a/lib/text.js
+++ b/lib/text.js
@@ -12,6 +12,12 @@ exports.BAHTTEXT = function() {
 };
 
 exports.CHAR = function(number) {
+  if (number === undefined || number === 0) {
+    return error.value;
+  }
+  if (number instanceof Error) {
+    return number;
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -20,24 +26,33 @@ exports.CHAR = function(number) {
 };
 
 exports.CLEAN = function(text) {
+  if (text instanceof Error) {
+    return text;
+  }
   text = text || '';
   var re = /[\0-\x1F]/g;
   return text.replace(re, "");
 };
 
 exports.CODE = function(text) {
+  if (text instanceof Error) {
+    return text;
+  }
   text = text || '';
   var result = text.charCodeAt(0);
 
   if (isNaN(result)) {
-    result = error.na;
+    result = error.value;
   }
   return result;
 };
 
 exports.CONCATENATE = function() {
   var args = utils.flatten(arguments);
-
+  var someError = args.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
   var trueFound = 0;
   while ((trueFound = args.indexOf(true)) > -1) {
     args[trueFound] = 'TRUE';
@@ -67,6 +82,18 @@ exports.EXACT = function(text1, text2) {
   if (arguments.length !== 2) {
     return error.na;
   }
+  if (text1 instanceof Error) {
+    return text1;
+  }
+  if (text2 instanceof Error) {
+    return text2;
+  }
+  if (text1 === undefined || text1 === null) {
+    text1 = '';
+  }
+  if (text2 === undefined || text2 === null) {
+    text2 = '';
+  }
   return text1 === text2;
 };
 
@@ -74,8 +101,18 @@ exports.FIND = function(find_text, within_text, position) {
   if (arguments.length < 2) {
     return error.na;
   }
+  if (find_text === undefined || find_text === null) {
+    find_text = '';
+  }
+  if (within_text === undefined || within_text === null) {
+    within_text = '';
+  }
   position = (position === undefined) ? 0 : position;
-  return within_text ? within_text.indexOf(find_text, position - 1) + 1 : null;
+  var found_index = within_text.indexOf(find_text, position - 1);
+  if (found_index === -1) {
+    return error.value;
+  }
+  return found_index + 1;
 };
 
 //TODO
@@ -84,6 +121,9 @@ exports.FIXED = function() {
 };
 
 exports.HTML2TEXT = function (value) {
+  if (value instanceof Error) {
+    return value;
+  }
   var result = '';
 
   if (value) {
@@ -103,12 +143,21 @@ exports.HTML2TEXT = function (value) {
 };
 
 exports.LEFT = function(text, number) {
+  if (text instanceof Error) {
+    return text;
+  }
+  if (number instanceof Error) {
+    return number;
+  }
+  if (text === undefined || text === null) {
+    text = '';
+  }
   number = (number === undefined) ? 1 : number;
   number = utils.parseNumber(number);
   if (number instanceof Error || typeof text !== 'string') {
     return error.value;
   }
-  return text ? text.substring(0, number) : null;
+  return text.substring(0, number);
 };
 
 exports.LEN = function(text) {
@@ -116,22 +165,32 @@ exports.LEN = function(text) {
     return error.error;
   }
 
-  if (text === null) {
+  if (text === undefined || text === null) {
     return 0;
   }
 
-  if (typeof text === 'string') {
-    return text ? text.length : 0;
+  if (text instanceof Error) {
+    return text;
   }
 
   if (Array.isArray(text)) {
-    return error.error
+    return error.value;
   }
 
-  return error.value;
+  var textAsString = text.toString();
+  return textAsString.length;
 };
 
 exports.LOWER = function(text) {
+  if (arguments.length !== 1) {
+    return error.value;
+  }
+  if (text instanceof Error) {
+    return text;
+  }
+  if (text === undefined || text === null) {
+    return '';
+  }
   if (typeof text !== 'string') {
     return error.value;
   }
@@ -139,6 +198,9 @@ exports.LOWER = function(text) {
 };
 
 exports.MID = function(text, start, number) {
+  if (start === undefined || start === null) {
+    return error.value;
+  }
   start = utils.parseNumber(start);
   number = utils.parseNumber(number);
   if (utils.anyIsError(start, number) || typeof text !== 'string') {
@@ -164,8 +226,11 @@ exports.PRONETIC = function() {
 };
 
 exports.PROPER = function(text) {
-  if (text === undefined || text.length === 0) {
-    return error.value;
+  if (text instanceof Error) {
+    return text;
+  }
+  if (text === undefined || text === null || text.length === 0) {
+    return '';
   }
   if (text === true) {
     text = 'TRUE';
@@ -220,6 +285,15 @@ exports.REPLACE = function(text, position, length, new_text) {
 };
 
 exports.REPT = function(text, number) {
+  if (text instanceof Error) {
+    return text;
+  }
+  if (number instanceof Error) {
+    return number;
+  }
+  if (text === undefined || text === null) {
+    text = '';
+  }
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -228,12 +302,21 @@ exports.REPT = function(text, number) {
 };
 
 exports.RIGHT = function(text, number) {
+  if (text instanceof Error) {
+    return text;
+  }
+  if (number instanceof Error) {
+    return number;
+  }
+  if (text === undefined || text === null) {
+    text = '';
+  }
   number = (number === undefined) ? 1 : number;
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
   }
-  return text ? text.substring(text.length - number) : error.na;
+  return text.substring(text.length - number);
 };
 
 exports.SEARCH = function(find_text, within_text, position) {
@@ -272,6 +355,12 @@ exports.SUBSTITUTE = function(text, old_text, new_text, occurrence) {
 };
 
 exports.T = function(value) {
+  if (value === undefined || value === null) {
+    value = '';
+  }
+  if (value instanceof Error) {
+    return value;
+  }
   return (typeof value === "string") ? value : '';
 };
 
@@ -281,6 +370,12 @@ exports.TEXT = function() {
 };
 
 exports.TRIM = function(text) {
+  if (text === undefined || text === null) {
+    text = '';
+  }
+  if (text instanceof Error) {
+    return text;
+  }
   if (typeof text !== 'string') {
     return error.value;
   }
@@ -292,6 +387,12 @@ exports.UNICHAR = exports.CHAR;
 exports.UNICODE = exports.CODE;
 
 exports.UPPER = function(text) {
+  if (text === undefined || text === null) {
+    text = '';
+  }
+  if (text instanceof Error) {
+    return text;
+  }
   if (typeof text !== 'string') {
     return error.value;
   }

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -103,7 +103,10 @@ exports.parseBool = function(bool) {
 };
 
 exports.parseNumber = function(string) {
-  if (string === undefined || string === '') {
+  if (string === undefined || string === null) {
+    return 0;
+  }
+  if (string === '') {
     return error.value;
   }
   if (!isNaN(string)) {
@@ -123,8 +126,11 @@ exports.parseNumberArray = function(arr) {
   var parsed;
 
   while (len--) {
+    if (arr[len] instanceof Error) {
+      return arr[len];
+    }
     parsed = exports.parseNumber(arr[len]);
-    if (parsed === error.value) {
+    if (parsed instanceof Error) {
       return parsed;
     }
     arr[len] = parsed;

--- a/test/logical.js
+++ b/test/logical.js
@@ -5,6 +5,9 @@ var should = require('should');
 
 describe('Logical', function() {
   it('AND', function() {
+    logical.AND(undefined, undefined).should.equal(error.value);
+    logical.AND(undefined, true).should.equal(true);
+    logical.AND(error.na, true).should.equal(error.na);
     logical.AND(true, true).should.equal(true);
     logical.AND(true, false).should.equal(false);
   });
@@ -23,6 +26,11 @@ describe('Logical', function() {
   });
 
   it('IF', function() {
+    logical.IF(undefined, undefined, undefined).should.equal(0);
+    logical.IF(undefined, 1, 2).should.equal(2);
+    logical.IF(error.na, undefined).should.equal(error.na);
+    logical.IF(true, error.na).should.equal(error.na);
+
     logical.IF(true, 1, 2).should.equal(1);
     logical.IF(false, 1, 2).should.equal(2);
     logical.IF(true).should.equal(true);
@@ -54,6 +62,9 @@ describe('Logical', function() {
   });
 
   it('OR', function() {
+    logical.OR(undefined, undefined).should.equal(error.value);
+    logical.OR(undefined, false).should.equal(false);
+    logical.OR(error.na, false).should.equal(error.na);
     logical.OR(true).should.equal(true);
     logical.OR(false).should.equal(false);
     logical.OR(true, false).should.equal(true);

--- a/test/math-trig.js
+++ b/test/math-trig.js
@@ -5,33 +5,43 @@ var should = require('should');
 
 describe('Math & Trig', function () {
   it('ABS', function () {
-    mathTrig.ABS().should.equal(error.value);
+    mathTrig.ABS().should.equal(0);
+    mathTrig.ABS(undefined).should.equal(0);
+    mathTrig.ABS(error.na).should.equal(error.na);
     mathTrig.ABS(-1).should.equal(1);
     mathTrig.ABS('invalid').should.equal(error.value);
   });
 
   it('ACOS', function () {
-    mathTrig.ACOS().should.equal(error.value);
+    mathTrig.ACOS().should.equal(mathTrig.ACOS(0));
+    mathTrig.ACOS(undefined).should.equal(mathTrig.ACOS(0));
+    mathTrig.ACOS(error.na).should.equal(error.na);
     mathTrig.ACOS(100).should.equal(error.num);
     mathTrig.ACOS(1).should.equal(0);
     mathTrig.ACOS('invalid').should.equal(error.value);
   });
 
   it('ACOSH', function() {
-    mathTrig.ACOSH().should.equal(error.value);
+    mathTrig.ACOSH().should.equal(error.num);
+    mathTrig.ACOSH(undefined).should.equal(error.num);
+    mathTrig.ACOSH(error.na).should.equal(error.na);
     mathTrig.ACOSH(-100).should.equal(error.num);
     mathTrig.ACOSH(1).should.equal(0);
     mathTrig.ACOSH('invalid').should.equal(error.value);
   });
 
   it('ACOT', function() {
-    mathTrig.ACOT().should.equal(error.value);
+    mathTrig.ACOT().should.equal(mathTrig.ACOT(0));
+    mathTrig.ACOT(undefined).should.equal(mathTrig.ACOT(0));
+    mathTrig.ACOT(error.na).should.equal(error.na);
     mathTrig.ACOT(1).should.approximately(0.7853981633974483, 1e-9);
     mathTrig.ACOT('invalid').should.equal(error.value);
   });
 
   it('ACOTH', function() {
-    mathTrig.ACOTH().should.equal(error.value);
+    mathTrig.ACOTH().should.equal(error.num);
+    mathTrig.ACOTH(undefined).should.equal(error.num);
+    mathTrig.ACOTH(error.na).should.equal(error.na);
     mathTrig.ACOTH(0.1).should.equal(error.num);
     mathTrig.ACOTH(1).should.equal(Infinity);
     mathTrig.ACOTH('invalid').should.equal(error.value);
@@ -40,9 +50,19 @@ describe('Math & Trig', function () {
   it('ADD', function() {
     mathTrig.ADD(10, 4).should.equal(14);
     mathTrig.ADD(1.2, 4).should.equal(5.2);
-    mathTrig.ADD().should.equal(error.na);
-    mathTrig.ADD(1).should.equal(error.na);
     mathTrig.ADD(1, 'string').should.equal(error.value);
+
+    mathTrig.ADD().should.equal(error.na);
+    mathTrig.ADD(undefined, undefined).should.equal(0);
+    mathTrig.ADD(1, undefined).should.equal(1);
+    mathTrig.ADD(undefined, 1).should.equal(1);
+    mathTrig.ADD(null, undefined).should.equal(0);
+    mathTrig.ADD(undefined, null).should.equal(0);
+    mathTrig.ADD(null, null).should.equal(0);
+    mathTrig.ADD(null, 1).should.equal(1);
+    mathTrig.ADD(error.na, undefined).should.equal(error.na);
+    mathTrig.ADD(error.na, null).should.equal(error.na);
+    mathTrig.ADD(error.na, 1).should.equal(error.na);
   });
 
 
@@ -71,44 +91,64 @@ describe('Math & Trig', function () {
   });
 
   it('ARABIC', function() {
+    mathTrig.ARABIC(undefined).should.equal(0);
+    mathTrig.ARABIC(error.na).should.equal(error.na);
     mathTrig.ARABIC('X').should.equal(10);
     mathTrig.ARABIC('ABC').should.equal(error.value);
   });
 
   it('ASIN', function() {
+    mathTrig.ASIN(undefined).should.equal(0);
+    mathTrig.ASIN(error.na).should.equal(error.na);
     mathTrig.ASIN(0.5).should.approximately(0.5235987755982989, 1e-9);
     mathTrig.ASIN(-100).should.equal(error.num);
     mathTrig.ASIN('invalid').should.equal(error.value);
   });
 
   it('ASINH', function() {
+    mathTrig.ASINH(undefined).should.equal(0);
+    mathTrig.ASINH(error.na).should.equal(error.na);
     mathTrig.ASINH(0.5).should.approximately(0.48121182505960347, 1e-9);
     mathTrig.ASINH('invalid').should.equal(error.value);
   });
 
   it('ATAN', function() {
+    mathTrig.ATAN(undefined).should.equal(0);
+    mathTrig.ATAN(error.na).should.equal(error.na);
     mathTrig.ATAN(1).should.approximately(0.7853981633974483, 1e-9);
     mathTrig.ATAN('invalid').should.equal(error.value);
   });
 
   it('ATAN2', function() {
+    mathTrig.ATAN2(undefined).should.equal(0);
+    mathTrig.ATAN2(error.na).should.equal(error.na);
     mathTrig.ATAN2(1, 1).should.approximately(0.7853981633974483, 1e-9);
     mathTrig.ATAN2(1, 'invalid').should.equal(error.value);
   });
 
   it('ATANH', function() {
+    mathTrig.ATANH(undefined).should.equal(0);
+    mathTrig.ATANH(error.na).should.equal(error.na);
     mathTrig.ATANH(1).should.equal(Infinity);
     mathTrig.ATANH('invalid').should.equal(error.value);
     mathTrig.ATANH(100).should.equal(error.num);
   });
 
   it('BASE', function() {
+    mathTrig.BASE(undefined, undefined).should.equal(error.num);
+    mathTrig.BASE(7, undefined).should.equal(error.num);
+    mathTrig.BASE(7, null).should.equal(error.num);
+    mathTrig.BASE(undefined, 2).should.equal('0');
+    mathTrig.BASE(error.na, 2).should.equal(error.na);
+    mathTrig.BASE(2, error.na).should.equal(error.na);
     mathTrig.BASE(7, 2).should.equal('111');
     mathTrig.BASE(400, 10, 10).should.equal('0000000400');
     mathTrig.BASE('invalid', 10, 10).should.equal(error.value);
   });
 
   it('CEILING', function() {
+    mathTrig.CEILING(undefined).should.equal(0);
+    mathTrig.CEILING(error.na).should.equal(error.na);
     mathTrig.CEILING(4.1).should.equal(5);
     mathTrig.CEILING(4.9).should.equal(5);
     mathTrig.CEILING(-4.1).should.equal(-4);
@@ -131,6 +171,8 @@ describe('Math & Trig', function () {
   });
 
   it('CEILING.MATH', function() {
+    mathTrig.CEILING.MATH(undefined).should.equal(0);
+    mathTrig.CEILING.MATH(error.na).should.equal(error.na);
     mathTrig.CEILING.MATH(24.3, 5).should.equal(25);
     mathTrig.CEILING.MATH(6.7).should.equal(7);
     mathTrig.CEILING.MATH(-8.1, 2).should.equal(-8);
@@ -139,6 +181,8 @@ describe('Math & Trig', function () {
   });
 
   it('CEILING.PRECISE', function() {
+    mathTrig.CEILING.PRECISE(undefined).should.equal(0);
+    mathTrig.CEILING.PRECISE(error.na).should.equal(error.na);
     mathTrig.CEILING.PRECISE(4.3).should.equal(5);
     mathTrig.CEILING.PRECISE(-4.3).should.equal(-4);
     mathTrig.CEILING.PRECISE(4.3, 2).should.equal(6);
@@ -149,6 +193,11 @@ describe('Math & Trig', function () {
   });
 
   it("COMBIN", function() {
+    mathTrig.COMBIN(undefined, undefined).should.equal(1);
+    mathTrig.COMBIN(10, undefined).should.equal(1);
+    mathTrig.COMBIN(undefined, 10).should.equal(error.num);
+    mathTrig.COMBIN(error.na).should.equal(error.na);
+    mathTrig.COMBIN(5, 10).should.equal(error.num);
     mathTrig.COMBIN(0, 0).should.equal(1);
     mathTrig.COMBIN(1, 0).should.equal(1);
     mathTrig.COMBIN(1, 1).should.equal(1);
@@ -162,6 +211,10 @@ describe('Math & Trig', function () {
   });
 
   it("COMBINA", function() {
+    mathTrig.COMBINA(undefined, undefined).should.equal(1);
+    mathTrig.COMBINA(10, undefined).should.equal(1);
+    mathTrig.COMBINA(undefined, 10).should.equal(error.num);
+    mathTrig.COMBINA(error.na).should.equal(error.na);
     mathTrig.COMBINA(0, 0).should.equal(1);
     mathTrig.COMBINA(1, 0).should.equal(1);
     mathTrig.COMBINA(1, 1).should.equal(1);
@@ -175,38 +228,54 @@ describe('Math & Trig', function () {
   });
 
   it('COS', function() {
+    mathTrig.COS(undefined).should.equal(1);
+    mathTrig.COS(error.na).should.equal(error.na);
     mathTrig.COS(0).should.equal(1);
     mathTrig.COS('invalid').should.equal(error.value);
   });
 
   it('COSH', function() {
+    mathTrig.COSH(undefined).should.equal(1);
+    mathTrig.COSH(error.na).should.equal(error.na);
     mathTrig.COSH(0).should.equal(1);
     mathTrig.COSH('invalid').should.equal(error.value);
   });
 
   it('COT', function() {
+    mathTrig.COT(undefined).should.equal(error.div0);
+    mathTrig.COT(0).should.equal(error.div0);
+    mathTrig.COT(error.na).should.equal(error.na);
     mathTrig.COT(1).should.approximately(0.6420926159343306, 1e-9);
     mathTrig.COT('invalid').should.equal(error.value);
   });
 
   it('COTH', function() {
+    mathTrig.COTH(undefined).should.equal(error.div0);
+    mathTrig.COTH(0).should.equal(error.div0);
+    mathTrig.COTH(error.na).should.equal(error.na);
     mathTrig.COTH(1).should.approximately(1.3130352854993312, 1e-9);
     mathTrig.COTH('invalid').should.equal(error.value);
   });
 
   it('CSC', function() {
-    mathTrig.CSC(0).should.equal(Infinity);
+    mathTrig.CSC(undefined).should.equal(error.div0);
+    mathTrig.CSC(0).should.equal(error.div0);
+    mathTrig.CSC(error.na).should.equal(error.na);
     mathTrig.CSC('invalid').should.equal(error.value);
   });
 
   it('CSCH', function() {
-    mathTrig.CSCH(0).should.equal(Infinity);
+    mathTrig.CSCH(undefined).should.equal(error.div0);
+    mathTrig.CSCH(0).should.equal(error.div0);
+    mathTrig.CSCH(error.na).should.equal(error.na);
     mathTrig.CSCH('invalid').should.equal(error.value);
   });
 
   it('DECIMAL', function() {
-    mathTrig.DECIMAL().should.equal(error.value);
-    mathTrig.DECIMAL(10.5).should.equal(10);
+    mathTrig.DECIMAL(undefined, undefined).should.equal(error.num);
+    mathTrig.DECIMAL(undefined, 2).should.equal(0);
+    mathTrig.DECIMAL(2, undefined).should.equal(error.num);
+    mathTrig.DECIMAL(error.na).should.equal(error.na);
     mathTrig.DECIMAL('0', 2).should.equal(0);
     mathTrig.DECIMAL('1', 2).should.equal(1);
     mathTrig.DECIMAL('10', 2).should.equal(2);
@@ -217,6 +286,8 @@ describe('Math & Trig', function () {
   });
 
   it('DEGREES', function() {
+    mathTrig.DEGREES(undefined).should.equal(0);
+    mathTrig.DEGREES(error.na).should.equal(error.na);
     mathTrig.DEGREES(Math.PI).should.equal(180);
     mathTrig.DEGREES('invalid').should.equal(error.value);
   });
@@ -227,12 +298,24 @@ describe('Math & Trig', function () {
     mathTrig.DIVIDE(0, 0).should.equal(error.div0);
     mathTrig.DIVIDE(1, 0).should.equal(error.div0);
     mathTrig.DIVIDE(0, 1).should.equal(0);
-    mathTrig.DIVIDE().should.equal(error.na);
-    mathTrig.DIVIDE(1).should.equal(error.na);
     mathTrig.DIVIDE(1, 'string').should.equal(error.value);
+
+    mathTrig.DIVIDE().should.equal(error.na);
+    mathTrig.DIVIDE(undefined, undefined).should.equal(error.div0);
+    mathTrig.DIVIDE(1, undefined).should.equal(error.div0);
+    mathTrig.DIVIDE(undefined, 1).should.equal(0);
+    mathTrig.DIVIDE(null, undefined).should.equal(error.div0);
+    mathTrig.DIVIDE(undefined, null).should.equal(error.div0);
+    mathTrig.DIVIDE(null, null).should.equal(error.div0);
+    mathTrig.DIVIDE(null, 1).should.equal(0);
+    mathTrig.DIVIDE(error.na, undefined).should.equal(error.na);
+    mathTrig.DIVIDE(error.na, null).should.equal(error.na);
+    mathTrig.DIVIDE(error.na, 1).should.equal(error.na);
   });
 
   it('EVEN', function() {
+    mathTrig.EVEN(undefined).should.equal(0);
+    mathTrig.EVEN(error.na).should.equal(error.na);
     mathTrig.EVEN(3).should.equal(4);
     mathTrig.EVEN('invalid').should.equal(error.value);
   });
@@ -246,29 +329,46 @@ describe('Math & Trig', function () {
     mathTrig.EQ(true, true).should.equal(true);
     mathTrig.EQ(false, false).should.equal(true);
     mathTrig.EQ(false, 0).should.equal(false);
+
     mathTrig.EQ().should.equal(error.na);
-    mathTrig.EQ(1).should.equal(error.na);
+    mathTrig.EQ(undefined, undefined).should.equal(true);
+    mathTrig.EQ(null, null).should.equal(true);
+    mathTrig.EQ(undefined, null).should.equal(true);
+    mathTrig.EQ(error.na).should.equal(error.na);
+    mathTrig.EQ(1, undefined).should.equal(false);
     mathTrig.EQ(1, 'string').should.equal(false);
   });
 
   it('EXP', function() {
     mathTrig.EXP().should.equal(error.na);
-    mathTrig.EXP('1').should.equal(error.error);
+    mathTrig.EXP(undefined).should.equal(1);
+    mathTrig.EXP(null).should.equal(1);
+    mathTrig.EXP(error.na).should.equal(error.na);
+    mathTrig.EXP('1').should.equal(2.718281828459045);
+    mathTrig.EXP('a').should.equal(error.value);
     mathTrig.EXP(1, 1).should.equal(error.error);
     mathTrig.EXP(1).should.equal(2.718281828459045);
   });
 
   it('FACT', function() {
+    mathTrig.FACT(undefined).should.equal(1);
+    mathTrig.FACT(error.na).should.equal(error.na);
     mathTrig.FACT(6).should.equal(720);
     mathTrig.FACT('invalid').should.equal(error.value);
   });
 
   it('FACTDOUBLE', function() {
+    mathTrig.FACTDOUBLE(undefined).should.equal(1);
+    mathTrig.FACTDOUBLE(error.na).should.equal(error.na);
     mathTrig.FACTDOUBLE(10).should.equal(3840);
     mathTrig.FACTDOUBLE('invalid').should.equal(error.value);
   });
 
   it('FLOOR', function() {
+    mathTrig.FLOOR(undefined, undefined).should.equal(0);
+    mathTrig.FLOOR(2, undefined).should.equal(0); // different than Excel
+    mathTrig.FLOOR(undefined, 2).should.equal(0);
+    mathTrig.FLOOR(error.na).should.equal(error.na);
     mathTrig.FLOOR(3.7, 2).should.equal(2);
     mathTrig.FLOOR(-2.5, -2).should.equal(-2);
     mathTrig.FLOOR(2.5, -2).should.equal(error.num);
@@ -279,17 +379,25 @@ describe('Math & Trig', function () {
   });
 
   it('FLOOR.PRECISE', function() {
+    mathTrig.FLOOR.PRECISE(undefined, undefined).should.equal(0);
+    mathTrig.FLOOR.PRECISE(2, undefined).should.equal(0);
+    mathTrig.FLOOR.PRECISE(undefined, 2).should.equal(0);
+    mathTrig.FLOOR.PRECISE(error.na).should.equal(error.na);
     mathTrig.FLOOR.PRECISE(2014.6, 0.2).should.equal(2014.4);
     mathTrig.FLOOR.PRECISE(-3.2,-1).should.equal(-4);
     mathTrig.FLOOR.PRECISE(3.2,1).should.equal(3);
     mathTrig.FLOOR.PRECISE(-3.2,1).should.equal(-4);
     mathTrig.FLOOR.PRECISE(3.2,-1).should.equal(3);
-    mathTrig.FLOOR.PRECISE(3.2).should.equal(3);
+    mathTrig.FLOOR.PRECISE(3.2).should.equal(0);
   });
 
   it('FLOOR.MATH', function() {
+    mathTrig.FLOOR.MATH(undefined, undefined).should.equal(0);
+    mathTrig.FLOOR.MATH(2, undefined).should.equal(0);
+    mathTrig.FLOOR.MATH(undefined, 2).should.equal(0);
+    mathTrig.FLOOR.MATH(error.na).should.equal(error.na);
     mathTrig.FLOOR.MATH(24.3, 5).should.equal(20);
-    mathTrig.FLOOR.MATH(6.7).should.equal(6);
+    mathTrig.FLOOR.MATH(6.7).should.equal(0);
     mathTrig.FLOOR.MATH(-8.1, 2).should.equal(-10);
     mathTrig.FLOOR.MATH(-8.1, 0).should.equal(0);
     mathTrig.FLOOR.MATH(-5.5, 2, -1).should.equal(-4);
@@ -299,12 +407,16 @@ describe('Math & Trig', function () {
     mathTrig.FLOOR.MATH(3.2, 1).should.equal(3);
     mathTrig.FLOOR.MATH(-3.2, 1).should.equal(-4);
     mathTrig.FLOOR.MATH(3.2, -1).should.equal(3);
-    mathTrig.FLOOR.MATH(3.2).should.equal(3);
+    mathTrig.FLOOR.MATH(3.2).should.equal(0);
     mathTrig.FLOOR.MATH(3.2, 0).should.equal(0);
     mathTrig.FLOOR.MATH(3.2, 'invalid').should.equal(error.value);
   });
 
   it('GCD', function() {
+    mathTrig.GCD(undefined, undefined).should.equal(error.value);
+    mathTrig.GCD(2, undefined).should.equal(2);
+    mathTrig.GCD(undefined, 1).should.equal(1);
+    mathTrig.GCD(error.na).should.equal(error.na);
     mathTrig.GCD(5, 2).should.equal(1);
     mathTrig.GCD(24, 36).should.equal(12);
     mathTrig.GCD(7, 1).should.equal(1);
@@ -317,17 +429,25 @@ describe('Math & Trig', function () {
     mathTrig.GTE(10, 10).should.equal(true);
     mathTrig.GTE(10, 12).should.equal(false);
     mathTrig.GTE().should.equal(error.na);
-    mathTrig.GTE(1).should.equal(error.na);
+    mathTrig.GTE(undefined, undefined).should.equal(true);
+    mathTrig.GTE(1, undefined).should.equal(true);
+    mathTrig.GTE(0, undefined).should.equal(true);
+    mathTrig.GTE(-1, undefined).should.equal(false);
+    mathTrig.GTE(error.na).should.equal(error.na);
     mathTrig.GTE(1, 'string').should.equal(error.error);
     mathTrig.GTE('string', 2).should.equal(error.error);
   });
 
   it('INT', function() {
+    mathTrig.INT(undefined).should.equal(0);
+    mathTrig.INT(error.na).should.equal(error.na);
     mathTrig.INT(5.5).should.equal(5);
     mathTrig.INT('invalid').should.equal(error.value);
   });
 
   it('ISO.CEILING', function() {
+    mathTrig.ISO.CEILING(undefined).should.equal(0);
+    mathTrig.ISO.CEILING(error.na).should.equal(error.na);
     mathTrig.ISO.CEILING(4.3).should.equal(5);
     mathTrig.ISO.CEILING(-4.3).should.equal(-4);
     mathTrig.ISO.CEILING(4.3, 2).should.equal(6);
@@ -338,12 +458,17 @@ describe('Math & Trig', function () {
   });
 
   it('LCM', function() {
-    mathTrig.LCM(5, 2).should.equal(10);
+    mathTrig.LCM(undefined, undefined).should.equal(error.value);
+    mathTrig.LCM(error.na, 36).should.equal(error.na);
+    mathTrig.LCM(24, error.na).should.equal(error.na);
+    mathTrig.LCM(5, undefined, 2).should.equal(10);
     mathTrig.LCM(24, 36).should.equal(72);
     mathTrig.LCM(24, 'invalid').should.equal(error.value);
   });
 
   it('LN', function() {
+    mathTrig.LN(undefined).should.equal(error.num);
+    mathTrig.LN(error.na).should.equal(error.na);
     mathTrig.LN(Math.E).should.equal(1);
     mathTrig.LN('invalid').should.equal(error.value);
   });
@@ -365,12 +490,19 @@ describe('Math & Trig', function () {
   });
 
   it('LOG', function() {
+    mathTrig.LOG(undefined, undefined).should.equal(error.num);
+    mathTrig.LOG(1, undefined).should.equal(error.num);
+    mathTrig.LOG(undefined, 1).should.equal(error.num);
+    mathTrig.LOG(1, error.na).should.equal(error.na);
+    mathTrig.LOG(error.na, 1).should.equal(error.na);
+
     mathTrig.LOG(10, 10).should.equal(1);
-    mathTrig.LOG(1).should.equal(0);
     mathTrig.LOG(10, 'invalid').should.equal(error.value);
   });
 
   it('LOG10', function() {
+    mathTrig.LOG10(undefined).should.equal(error.num);
+    mathTrig.LOG10(error.na).should.equal(error.na);
     mathTrig.LOG10(10).should.equal(1);
     mathTrig.LOG10('invalid').should.equal(error.value);
   });
@@ -380,7 +512,11 @@ describe('Math & Trig', function () {
     mathTrig.LT(10, 10).should.equal(false);
     mathTrig.LT(10, 12).should.equal(true);
     mathTrig.LT().should.equal(error.na);
-    mathTrig.LT(1).should.equal(error.na);
+    mathTrig.LT(undefined, undefined).should.equal(false);
+    mathTrig.LT(1, undefined).should.equal(false);
+    mathTrig.LT(0, undefined).should.equal(false);
+    mathTrig.LT(-1, undefined).should.equal(true);
+    mathTrig.LT(error.na).should.equal(error.na);
     mathTrig.LT(1, 'string').should.equal(error.error);
     mathTrig.LT('string', 2).should.equal(error.error);
   });
@@ -390,7 +526,11 @@ describe('Math & Trig', function () {
     mathTrig.LTE(10, 10).should.equal(true);
     mathTrig.LTE(10, 12).should.equal(true);
     mathTrig.LTE().should.equal(error.na);
-    mathTrig.LTE(1).should.equal(error.na);
+    mathTrig.LTE(undefined, undefined).should.equal(true);
+    mathTrig.LTE(1, undefined).should.equal(false);
+    mathTrig.LTE(0, undefined).should.equal(true);
+    mathTrig.LTE(-1, undefined).should.equal(true);
+    mathTrig.LTE(error.na).should.equal(error.na);
     mathTrig.LTE(1, 'string').should.equal(error.error);
     mathTrig.LTE('string', 2).should.equal(error.error);
   });
@@ -398,12 +538,28 @@ describe('Math & Trig', function () {
   it('MINUS', function() {
     mathTrig.MINUS(10, 4).should.equal(6);
     mathTrig.MINUS(1.2, 4).should.equal(-2.8);
-    mathTrig.MINUS().should.equal(error.na);
-    mathTrig.MINUS(1).should.equal(error.na);
     mathTrig.MINUS(1, 'string').should.equal(error.value);
+
+    mathTrig.MINUS().should.equal(error.na);
+    mathTrig.MINUS(undefined, undefined).should.equal(0);
+    mathTrig.MINUS(1, undefined).should.equal(1);
+    mathTrig.MINUS(undefined, 1).should.equal(-1);
+    mathTrig.MINUS(null, undefined).should.equal(0);
+    mathTrig.MINUS(undefined, null).should.equal(0);
+    mathTrig.MINUS(null, null).should.equal(0);
+    mathTrig.MINUS(null, 1).should.equal(-1);
+    mathTrig.MINUS(error.na, undefined).should.equal(error.na);
+    mathTrig.MINUS(error.na, null).should.equal(error.na);
+    mathTrig.MINUS(error.na, 1).should.equal(error.na);
   });
 
   it('MOD', function() {
+    mathTrig.MOD(undefined, undefined).should.equal(error.div0);
+    mathTrig.MOD(1, undefined).should.equal(error.div0);
+    mathTrig.MOD(undefined, 1).should.equal(0);
+    mathTrig.MOD(1, error.na).should.equal(error.na);
+    mathTrig.MOD(error.na, 1).should.equal(error.na);
+
     mathTrig.MOD(3, 2).should.equal(1);
     mathTrig.MOD(-3, 2).should.equal(1);
     mathTrig.MOD(3, -2).should.equal(-1);
@@ -413,6 +569,12 @@ describe('Math & Trig', function () {
   });
 
   it('MROUND', function() {
+    mathTrig.MROUND(undefined, undefined).should.equal(0);
+    mathTrig.MROUND(1, undefined).should.equal(0);
+    mathTrig.MROUND(undefined, 1).should.equal(0);
+    mathTrig.MROUND(1, error.na).should.equal(error.na);
+    mathTrig.MROUND(error.na, 1).should.equal(error.na);
+
     mathTrig.MROUND(10, 3).should.equal(9);
     mathTrig.MROUND(-10, -3).should.equal(-9);
     mathTrig.MROUND(1.3, 0.2).should.approximately(1.4000000000000001, 1e-9);
@@ -421,6 +583,8 @@ describe('Math & Trig', function () {
   });
 
   it('MULTINOMIAL', function() {
+    mathTrig.MULTINOMIAL(undefined).should.equal(error.value);
+    mathTrig.MULTINOMIAL(error.na).should.equal(error.na);
     mathTrig.MULTINOMIAL(2, 3, 4).should.equal(1260);
     mathTrig.MULTINOMIAL([2, 3, 4]).should.equal(1260);
     mathTrig.MULTINOMIAL([2, 'invalid', 4]).should.equal(error.value);
@@ -432,9 +596,19 @@ describe('Math & Trig', function () {
     mathTrig.MULTIPLY(0, 0).should.equal(0);
     mathTrig.MULTIPLY(1, 0).should.equal(0);
     mathTrig.MULTIPLY(0, 1).should.equal(0);
-    mathTrig.MULTIPLY().should.equal(error.na);
-    mathTrig.MULTIPLY(1).should.equal(error.na);
     mathTrig.MULTIPLY(1, 'string').should.equal(error.value);
+
+    mathTrig.MULTIPLY().should.equal(error.na);
+    mathTrig.MULTIPLY(undefined, undefined).should.equal(0);
+    mathTrig.MULTIPLY(1, undefined).should.equal(0);
+    mathTrig.MULTIPLY(undefined, 1).should.equal(0);
+    mathTrig.MULTIPLY(null, undefined).should.equal(0);
+    mathTrig.MULTIPLY(undefined, null).should.equal(0);
+    mathTrig.MULTIPLY(null, null).should.equal(0);
+    mathTrig.MULTIPLY(null, 1).should.equal(0);
+    mathTrig.MULTIPLY(error.na, undefined).should.equal(error.na);
+    mathTrig.MULTIPLY(error.na, null).should.equal(error.na);
+    mathTrig.MULTIPLY(error.na, 1).should.equal(error.na);
   });
 
   it('NE', function() {
@@ -447,11 +621,18 @@ describe('Math & Trig', function () {
     mathTrig.NE(false, false).should.equal(false);
     mathTrig.NE(false, 0).should.equal(true);
     mathTrig.NE().should.equal(error.na);
-    mathTrig.NE(1).should.equal(error.na);
+    mathTrig.NE(undefined, undefined).should.equal(false);
+    mathTrig.NE(null, null).should.equal(false);
+    mathTrig.NE(undefined, null).should.equal(false);
+    mathTrig.NE(error.na).should.equal(error.na);
+    mathTrig.NE(1, undefined).should.equal(true);
     mathTrig.NE(1, 'string').should.equal(true);
   });
 
   it('ODD', function() {
+    mathTrig.ODD(undefined).should.equal(1);
+    mathTrig.ODD(error.na).should.equal(error.na);
+    mathTrig.ODD(0).should.equal(1);
     mathTrig.ODD(3).should.equal(3);
     mathTrig.ODD(2).should.equal(3);
     mathTrig.ODD(-1).should.equal(-1);
@@ -468,6 +649,11 @@ describe('Math & Trig', function () {
   });
 
   it('POWER', function() {
+    mathTrig.POWER(undefined, undefined).should.equal(error.num);
+    mathTrig.POWER(undefined, 2).should.equal(0);
+    mathTrig.POWER(5, undefined).should.equal(1);
+    mathTrig.POWER(error.na, 2).should.equal(error.na);
+    mathTrig.POWER(5, error.na).should.equal(error.na);
     mathTrig.POWER(5, 2).should.equal(25);
     mathTrig.POWER(98.6, 3.2).should.approximately(2401077.2220695773, 1e-9);
     mathTrig.POWER(4, 5 / 4).should.approximately(5.656854249492381, 1e-9);
@@ -476,15 +662,23 @@ describe('Math & Trig', function () {
   });
 
   it('POW', function() {
+    mathTrig.POW(undefined, undefined).should.equal(error.num);
+    mathTrig.POW(undefined, 2).should.equal(0);
+    mathTrig.POW(5, undefined).should.equal(1);
+    mathTrig.POW(error.na, 2).should.equal(error.na);
+    mathTrig.POW(5, error.na).should.equal(error.na);
     mathTrig.POW(5).should.equal(error.na);
     mathTrig.POW(5, 2).should.equal(25);
     mathTrig.POW(98.6, 3.2).should.approximately(2401077.2220695773, 1e-9);
     mathTrig.POW(4, 5 / 4).should.approximately(5.656854249492381, 1e-9);
     mathTrig.POW(-1, 0.5).should.equal(error.num);
-    mathTrig.POW(-1, 'invalid').should.equal(error.error);
+    mathTrig.POW(-1, 'invalid').should.equal(error.value);
   });
 
   it('PRODUCT', function() {
+    mathTrig.PRODUCT(undefined).should.equal(0);
+    mathTrig.PRODUCT(undefined, 1).should.equal(1);
+    mathTrig.PRODUCT(1, 2, error.na).should.equal(error.na);
     mathTrig.PRODUCT([5, 15, 30]).should.equal(2250);
     mathTrig.PRODUCT([5, 'invalid', 30]).should.equal(error.value);
   });
@@ -535,6 +729,10 @@ describe('Math & Trig', function () {
   });
 
   it('ROUND', function() {
+    mathTrig.ROUND(undefined, undefined).should.equal(0);
+    mathTrig.ROUND(2, undefined).should.equal(2);
+    mathTrig.ROUND(undefined, 2).should.equal(0);
+    mathTrig.ROUND(error.na).should.equal(error.na);
     mathTrig.ROUND(2.15, 1).should.approximately(2.2, 1e-9);
     mathTrig.ROUND(2.149, 1).should.approximately(2.1, 1e-9);
     mathTrig.ROUND(-1.475, 2).should.approximately(-1.47, 1e-9); //TODO: check if -1.48 would be the correct result or a precision error
@@ -546,6 +744,10 @@ describe('Math & Trig', function () {
   });
 
   it('ROUNDDOWN', function() {
+    mathTrig.ROUNDDOWN(undefined, undefined).should.equal(0);
+    mathTrig.ROUNDDOWN(2, undefined).should.equal(2);
+    mathTrig.ROUNDDOWN(undefined, 2).should.equal(0);
+    mathTrig.ROUNDDOWN(error.na).should.equal(error.na);
     mathTrig.ROUNDDOWN(3.2, 0).should.equal(3);
     mathTrig.ROUNDDOWN(76.9, 0).should.equal(76);
     mathTrig.ROUNDDOWN(3.14159, 3).should.approximately(3.141, 1e-9);
@@ -555,6 +757,10 @@ describe('Math & Trig', function () {
   });
 
   it('ROUNDUP', function() {
+    mathTrig.ROUNDUP(undefined, undefined).should.equal(0);
+    mathTrig.ROUNDUP(2, undefined).should.equal(2);
+    mathTrig.ROUNDUP(undefined, 2).should.equal(0);
+    mathTrig.ROUNDUP(error.na).should.equal(error.na);
     mathTrig.ROUNDUP(3.2, 0).should.equal(4);
     mathTrig.ROUNDUP(76.9, 0).should.equal(77);
     mathTrig.ROUNDUP(3.14159, 3).should.approximately(3.142, 1e-9);
@@ -564,12 +770,16 @@ describe('Math & Trig', function () {
   });
 
   it('SEC', function() {
+    mathTrig.SEC(undefined).should.equal(1);
+    mathTrig.SEC(error.na).should.equal(error.na);
     mathTrig.SEC(45).should.approximately(1.9035944074044246, 1e-9);
     mathTrig.SEC(30).should.approximately(6.482921234962678, 1e-9);
     mathTrig.SEC('invalid').should.equal(error.value);
   });
 
   it('SECH', function() {
+    mathTrig.SECH(undefined).should.equal(1);
+    mathTrig.SECH(error.na).should.equal(error.na);
     mathTrig.SECH(45).should.approximately(5.725037161098787e-20, 1e-9);
     mathTrig.SECH(30).should.approximately(1.8715245937680347e-13, 1e-9);
     mathTrig.SECH('invalid').should.equal(error.value);
@@ -584,6 +794,8 @@ describe('Math & Trig', function () {
   });
 
   it('SIGN', function() {
+    mathTrig.SIGN(undefined).should.equal(0);
+    mathTrig.SIGN(error.na).should.equal(error.na);
     mathTrig.SIGN(0).should.equal(0);
     mathTrig.SIGN(-5).should.equal(-1);
     mathTrig.SIGN(5).should.equal(1);
@@ -591,22 +803,30 @@ describe('Math & Trig', function () {
   });
 
   it('SIN', function() {
+    mathTrig.SIN(undefined).should.equal(0);
+    mathTrig.SIN(error.na).should.equal(error.na);
     mathTrig.SIN(Math.PI / 2).should.equal(1);
     mathTrig.SIN('invalid').should.equal(error.value);
   });
 
   it('SINH', function() {
+    mathTrig.SINH(undefined).should.equal(0);
+    mathTrig.SINH(error.na).should.equal(error.na);
     mathTrig.SINH(1).should.approximately(1.1752011936438014, 1e-9); // the golden ratio: http://mathworld.wolfram.com/HyperbolicSine.html
     mathTrig.SINH('invalid').should.equal(error.value);
   });
 
   it('SQRT', function() {
+    mathTrig.SQRT(undefined).should.equal(0);
+    mathTrig.SQRT(error.na).should.equal(error.na);
     mathTrig.SQRT(4).should.equal(2);
     mathTrig.SQRT(-1).should.equal(error.num);
     mathTrig.SQRT('invalid').should.equal(error.value);
   });
 
   it('SQRTPI', function() {
+    mathTrig.SQRTPI(undefined).should.equal(0);
+    mathTrig.SQRTPI(error.na).should.equal(error.na);
     mathTrig.SQRTPI(3).should.approximately(3.0699801238394655, 1e-9);
     mathTrig.SQRTPI('invalid').should.equal(error.value);
   });
@@ -646,6 +866,8 @@ describe('Math & Trig', function () {
   });
 
   it("SUM", function() {
+    mathTrig.SUM(undefined, 1).should.equal(1);
+    mathTrig.SUM(1, 2, error.na).should.equal(error.na);
     mathTrig.SUM(1, 2, 3).should.equal(6);
     mathTrig.SUM([1, 2, 3]).should.equal(6);
     mathTrig.SUM([1, 2, 3], 1, 2).should.equal(9);
@@ -675,9 +897,24 @@ describe('Math & Trig', function () {
       [3, 3]
     ]).should.equal(24);
     mathTrig.SUM(1, 'invalid').should.equal(1);
+    mathTrig.SUM(undefined).should.equal(0);
+    mathTrig.SUM(undefined, 1).should.equal(1);
+    mathTrig.SUM(null).should.equal(0);
+    mathTrig.SUM(null, 1).should.equal(1);
+    mathTrig.SUM(error.na).should.equal(error.na);
+    mathTrig.SUM(undefined, error.na).should.equal(error.na);
+    mathTrig.SUM(error.na, 1).should.equal(error.na);
   });
 
   it("SUMIF", function() {
+    mathTrig.SUMIF([undefined], undefined).should.equal(0);
+    mathTrig.SUMIF([1, 2, 3], undefined).should.equal(0);
+    mathTrig.SUMIF([1, 2, 3], error.na).should.equal(0);
+    mathTrig.SUMIF([undefined], '>2').should.equal(0);
+    mathTrig.SUMIF([1, 2, error.na], error.na).should.equal(0);
+    mathTrig.SUMIF([2, error.na], '>1').should.equal(2);
+    mathTrig.SUMIF([error.na], '>1').should.equal(0);
+    mathTrig.SUMIF([error.na], '>1', [error.na]).should.equal(0);
     mathTrig.SUMIF([1, 2, 3], '>2').should.equal(3);
     mathTrig.SUMIF([
       [1, 1],
@@ -704,6 +941,8 @@ describe('Math & Trig', function () {
   });
 
   it('SUMPRODUCT', function() {
+    mathTrig.SUMPRODUCT([[3, 4], [8, error.na],], [[2, 7], [6, 7]]).should.equal(error.na);
+    mathTrig.SUMPRODUCT([[undefined, undefined]], [[undefined, undefined]]).should.equal(0);
     mathTrig.SUMPRODUCT([
       [3, 4],
       [8, 6],
@@ -778,17 +1017,24 @@ describe('Math & Trig', function () {
   });
 
   it('TAN', function() {
+    mathTrig.TAN(undefined).should.equal(0);
+    mathTrig.TAN(error.na).should.equal(error.na);
     mathTrig.TAN(mathTrig.RADIANS(45)).should.approximately(1, 1e-9);
     mathTrig.TAN('invalid').should.equal(error.value);
   });
 
   it('TANH', function() {
+    mathTrig.TANH(undefined).should.equal(0);
+    mathTrig.TANH(error.na).should.equal(error.na);
     mathTrig.TANH(0.5).should.approximately(0.46211715726000974, 1e-9);
     mathTrig.TANH('invalid').should.equal(error.value);
   });
 
   it('TRUNC', function() {
-    mathTrig.TRUNC(8.9).should.equal(8);
+    mathTrig.TRUNC(undefined, undefined).should.equal(0);
+    mathTrig.TRUNC(2, undefined).should.equal(2);
+    mathTrig.TRUNC(undefined, 2).should.equal(0);
+    mathTrig.TRUNC(error.na).should.equal(error.na);
     mathTrig.TRUNC(-8.9).should.equal(-8);
     mathTrig.TRUNC(0.45).should.equal(0);
     mathTrig.TRUNC('invalid').should.equal(error.value);

--- a/test/statistical.js
+++ b/test/statistical.js
@@ -6,6 +6,9 @@ var should = require('should');
 
 describe('Statistical', function() {
   it("AVEDEV", function() {
+    statistical.AVEDEV(undefined).should.equal(error.num);
+    statistical.AVEDEV(2, undefined, undefined).should.equal(0);
+    statistical.AVEDEV(error.na).should.equal(error.na);
     statistical.AVEDEV(2, 4, 8, 16).should.approximately(4.5, 1e-9);
     statistical.AVEDEV([2, 4, 8, 16]).should.approximately(4.5, 1e-9);
     statistical.AVEDEV([2, 4], [8, 16]).should.approximately(4.5, 1e-9);
@@ -17,6 +20,9 @@ describe('Statistical', function() {
   });
 
   it("AVERAGE", function() {
+    statistical.AVERAGE(undefined).should.equal(error.div0);
+    statistical.AVERAGE(2, undefined, undefined).should.equal(2);
+    statistical.AVERAGE(error.na).should.equal(error.na);
     statistical.AVERAGE(2, 4, 8, 16).should.approximately(7.5, 1e-9);
     statistical.AVERAGE([2, 4, 8, 16]).should.approximately(7.5, 1e-9);
     statistical.AVERAGE([2, 4], [8, 16]).should.approximately(7.5, 1e-9);
@@ -32,6 +38,9 @@ describe('Statistical', function() {
   });
 
   it("AVERAGEA", function() {
+    statistical.AVERAGEA(undefined).should.equal(error.div0);
+    statistical.AVERAGEA(2, undefined, undefined).should.equal(2);
+    statistical.AVERAGEA(error.na).should.equal(error.na);
     statistical.AVERAGEA(2, 4, 8, 16).should.approximately(7.5, 1e-9);
     statistical.AVERAGEA([2, 4, 8, 16]).should.approximately(7.5, 1e-9);
     statistical.AVERAGEA([2, 4], [8, 16]).should.approximately(7.5, 1e-9);
@@ -40,6 +49,7 @@ describe('Statistical', function() {
   });
 
   it("AVERAGEIF", function() {
+    statistical.AVERAGEIF([undefined], '>5').should.equal(error.value); // different than Excel
     statistical.AVERAGEIF([2, 4, 8, 16], '>5').should.equal(12);
     statistical.AVERAGEIF([2, 4, 8, 16], '*').should.equal(7.5);
     statistical.AVERAGEIF([2, 4, 8, 16], '>5', [1, 2, 3, 4]).should.approximately(3.5, 1e-9);
@@ -166,6 +176,8 @@ describe('Statistical', function() {
 
   it("COUNT", function() {
     statistical.COUNT().should.equal(0);
+    statistical.COUNT(undefined).should.equal(0);
+    statistical.COUNT(error.na).should.equal(error.na);
     statistical.COUNT(1, 2, 3, 4).should.equal(4);
     statistical.COUNT([1, 2, 3, 4]).should.equal(4);
     statistical.COUNT([1, 2], [3, 4]).should.equal(4);
@@ -187,6 +199,8 @@ describe('Statistical', function() {
 
   it("COUNTA", function() {
     statistical.COUNTA().should.equal(0);
+    statistical.COUNTA(undefined).should.equal(0);
+    statistical.COUNTA(error.na).should.equal(error.na);
     statistical.COUNTA(1, null, 3, 'a', '', 'c').should.equal(4);
     statistical.COUNTA([1, null, 3, 'a', '', 'c']).should.equal(4);
     statistical.COUNTA([1, null, 3], ['a', '', 'c']).should.equal(4);
@@ -198,6 +212,8 @@ describe('Statistical', function() {
 
   it("COUNTBLANK", function() {
     statistical.COUNTBLANK().should.equal(0);
+    statistical.COUNTBLANK(undefined).should.equal(1);
+    statistical.COUNTBLANK(error.na).should.equal(error.na);
     statistical.COUNTBLANK(1, null, 3, 'a', '', 'c').should.equal(2);
     statistical.COUNTBLANK([1, null, 3, 'a', '', 'c']).should.equal(2);
     statistical.COUNTBLANK([1, null, 3], ['a', '', 'c']).should.equal(2);
@@ -208,6 +224,8 @@ describe('Statistical', function() {
   });
 
   it("COUNTIF", function() {
+    statistical.COUNTIF([undefined], '>1').should.equal(0);
+    statistical.COUNTIF([error.na], '>1').should.equal(error.na);
     statistical.COUNTIF([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIF([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIF([
@@ -225,6 +243,8 @@ describe('Statistical', function() {
   });
 
   it("COUNTIFS", function() {
+    statistical.COUNTIFS([undefined], '>1').should.equal(0);
+    statistical.COUNTIFS([error.na], '>1').should.equal(error.na);
     statistical.COUNTIFS([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIFS([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIFS([
@@ -526,6 +546,8 @@ describe('Statistical', function() {
 
   it("MAX", function() {
     statistical.MAX().should.equal(0);
+    statistical.MAX(undefined).should.equal(0);
+    statistical.MAX(error.na).should.equal(error.na);
     statistical.MAX([0.1, 0.2], [0.4, 0.8], [true, false]).should.approximately(0.8, 1e-9);
     statistical.MAX([
       [0, 0.1, 0.2],
@@ -536,6 +558,8 @@ describe('Statistical', function() {
 
   it("MAXA", function() {
     statistical.MAXA().should.equal(0);
+    statistical.MAXA(undefined).should.equal(0);
+    statistical.MAXA(error.na).should.equal(error.na);
     statistical.MAXA([0.1, 0.2], [0.4, 0.8], [true, false]).should.equal(1);
     statistical.MAXA([
       [0.1, 0.2],
@@ -546,12 +570,16 @@ describe('Statistical', function() {
 
   it('MEDIAN', function() {
     statistical.MEDIAN().should.equal(error.num);
+    statistical.MEDIAN(undefined).should.equal(error.num);
+    statistical.MEDIAN(error.na).should.equal(error.na);
     statistical.MEDIAN(1, 2, 3, 4, 5).should.equal(3);
     statistical.MEDIAN(1, 2, 3, 4, 5, 6).should.approximately(3.5, 1e-9);
   });
 
   it("MIN", function() {
     statistical.MIN().should.equal(0);
+    statistical.MIN(undefined).should.equal(0);
+    statistical.MIN(error.na).should.equal(error.na);
     statistical.MIN([0.1, 0.2], [0.4, 0.8], [true, false]).should.approximately(0.1, 1e-9);
     statistical.MIN([0, 0.1, 0.2], [0.4, 0.8, 1], [true, false]).should.equal(0);
     statistical.MIN([
@@ -568,6 +596,8 @@ describe('Statistical', function() {
 
   it("MINA", function() {
     statistical.MINA().should.equal(0);
+    statistical.MINA(undefined).should.equal(0);
+    statistical.MINA(error.na).should.equal(error.na);
     statistical.MINA([0.1, 0.2], [0.4, 0.8], [true, false]).should.equal(0);
     statistical.MINA([
       [10, 0],

--- a/test/text.js
+++ b/test/text.js
@@ -16,28 +16,38 @@ describe('Text', function() {
     text.CHAR(65).should.equal("A");
     text.CHAR(255).should.equal("ÿ");
     text.CHAR(1000).should.equal("Ϩ");
+    text.CHAR(undefined).should.equal(error.value);
+    text.CHAR(error.na).should.equal(error.na);
     text.CHAR('invalid').should.equal(error.value);
   });
 
   it('CLEAN', function() {
+    text.CLEAN(undefined).should.equal('');
+    text.CLEAN(error.na).should.equal(error.na);
     text.CLEAN('Monthly Report').should.equal('Monthly Report');
   });
 
   it('CODE', function() {
-    text.CODE().should.equal(error.na);
+    text.CODE().should.equal(error.value);
+    text.CODE(undefined).should.equal(error.value);
+    text.CODE(error.na).should.equal(error.na);
     text.CODE('A').should.equal(65);
     text.CODE("Ϩ").should.equal(1000);
   });
 
   it('CONCATENATE', function() {
+    text.CONCATENATE('a', undefined, 'b').should.equal('ab');
+    text.CONCATENATE('a', error.na, 'b').should.equal(error.na);
     text.CONCATENATE('hello', ' ', 'world').should.equal('hello world');
     text.CONCATENATE(['hello', ' my ', 'world']).should.equal('hello my world');
     text.CONCATENATE(1, 'one').should.equal('1one');
     text.CONCATENATE(true, 'yes').should.equal('TRUEyes');
     text.CONCATENATE(false, 'no').should.equal('FALSEno');
   });
-  
+
   it('CONCAT', function() {
+    text.CONCAT('a', undefined, 'b').should.equal('ab');
+    text.CONCAT('a', error.na, 'b').should.equal(error.na);
     text.CONCAT('hello', ' ', 'world').should.equal('hello world');
     text.CONCAT(['hello', ' my ', 'world']).should.equal('hello my world');
     text.CONCAT(1, 'one').should.equal('1one');
@@ -59,6 +69,10 @@ describe('Text', function() {
   });
 
   it('EXACT', function() {
+    text.EXACT(undefined, undefined).should.equal(true);
+    text.EXACT(undefined, null).should.equal(true);
+    text.EXACT(undefined, "").should.equal(true);
+    text.EXACT(error.na, error.na).should.equal(error.na);
     text.EXACT('yes', 'yes').should.equal(true);
     text.EXACT('yes', 'yes', 'yes').should.equal(error.na);
     text.EXACT().should.equal(error.na);
@@ -66,10 +80,11 @@ describe('Text', function() {
 
   it('FIND', function() {
     var data = 'Miriam McGovern';
+    text.FIND(undefined, undefined).should.equal(1);
     text.FIND('M', data).should.equal(1);
     text.FIND('m', data).should.equal(6);
     text.FIND('M', data, 3).should.equal(8);
-    text.FIND('M').should.equal(error.na);
+    text.FIND('M', undefined).should.equal(error.value);
     text.FIND().should.equal(error.na);
   });
 
@@ -83,27 +98,38 @@ describe('Text', function() {
 
   it('HTML2TEXT', function() {
     text.HTML2TEXT().should.equal("");
+    text.HTML2TEXT(undefined).should.equal("");
+    text.HTML2TEXT(error.na).should.equal(error.na);
     text.HTML2TEXT('').should.equal("");
     text.HTML2TEXT('<i>Hello</i>').should.equal("Hello");
     text.HTML2TEXT(['<i>Hello</i>', '<b>Jim</b>']).should.equal("Hello\nJim");
   });
 
   it('LEFT', function() {
+    text.LEFT(error.na, 2).should.equal(error.na);
+    text.LEFT('text', error.na).should.equal(error.na);
+    text.LEFT(undefined, undefined).should.equal('');
+    text.LEFT(undefined, 3).should.equal('');
     text.LEFT('Sale Price', 4).should.equal('Sale');
     text.LEFT('Sweeden').should.equal('S');
     text.LEFT(3).should.equal(error.value);
   });
 
   it('LEN', function() {
-    text.LEN(true).should.equal(error.value);
+    text.LEN(undefined).should.equal(0);
+    text.LEN(error.na).should.equal(error.na);
+    text.LEN(true).should.equal(4);
     text.LEN('four').should.equal(4);
-    text.LEN([1, 2, 3, 4, 5]).should.equal(error.error);
+    text.LEN([1, 2, 3, 4, 5]).should.equal(error.value);
     text.LEN().should.equal(error.error);
     text.LEN(null).should.equal(0);
-    text.LEN([]).should.equal(error.error);
+    text.LEN([]).should.equal(error.value);
+    text.LEN(123).should.equal(3);
   });
 
   it("LOWER", function() {
+    text.LOWER(undefined).should.equal("");
+    text.LOWER(error.na).should.equal(error.na);
     text.LOWER('abcd').should.equal("abcd");
     text.LOWER('ABcd').should.equal("abcd");
     text.LOWER('ABCD').should.equal("abcd");
@@ -130,12 +156,14 @@ describe('Text', function() {
   });
 
   it('PROPER', function() {
+    text.PROPER(undefined).should.equal('');
+    text.PROPER(null).should.equal('');
+    text.PROPER(error.na).should.equal(error.na);
     text.PROPER('a title case').should.equal('A Title Case');
     text.PROPER(true).should.equal('True');
     text.PROPER(false).should.equal('False');
     text.PROPER(90).should.equal('90');
     text.PROPER(NaN).should.equal(error.value);
-    text.PROPER().should.equal(error.value);
   });
 
   it('REGEXEXTRACT', function() {
@@ -168,15 +196,22 @@ describe('Text', function() {
   });
 
   it('REPT', function() {
+    text.REPT(undefined, undefined).should.equal('');
+    text.REPT('text', undefined).should.equal('');
+    text.REPT(undefined, 3).should.equal('');
+    text.REPT(error.na, 3).should.equal(error.na);
     text.REPT('multiple ', 3).should.equal('multiple multiple multiple ');
-    text.REPT('m').should.equal(error.value);
+    text.REPT('m').should.equal('');
   });
 
   it('RIGHT', function() {
+    text.RIGHT(error.na, 2).should.equal(error.na);
+    text.RIGHT('text', error.na).should.equal(error.na);
+    text.RIGHT(undefined, undefined).should.equal('');
+    text.RIGHT(undefined, 3).should.equal('');
     text.RIGHT('Sale Price', 5).should.equal('Price');
     text.RIGHT('Stock Number').should.equal('r');
     text.RIGHT('something', 'invalid').should.equal(error.value);
-    text.RIGHT().should.equal(error.na);
   });
 
   it('SEARCH', function() {
@@ -205,6 +240,8 @@ describe('Text', function() {
   });
 
   it('T', function() {
+    text.T(undefined).should.equal('');
+    text.T(error.na).should.equal(error.na);
     text.T('Rainfall').should.equal('Rainfall');
     text.T(19).should.equal('');
     text.T(true).should.equal('');
@@ -218,11 +255,15 @@ describe('Text', function() {
   });
 
   it('TRIM', function() {
+    text.TRIM(undefined).should.equal('');
+    text.TRIM(error.na).should.equal(error.na);
     text.TRIM(' more  spaces ').should.equal('more spaces');
     text.TRIM(true).should.equal(error.value);
   });
 
   it('UNICHAR', function() {
+    text.UNICHAR(undefined).should.equal(error.value);
+    text.UNICHAR(error.na).should.equal(error.na);
     text.UNICHAR(65).should.equal("A");
     text.UNICHAR(255).should.equal("ÿ");
     text.UNICHAR(1000).should.equal("Ϩ");
@@ -233,11 +274,15 @@ describe('Text', function() {
   });
 
   it('UNICODE', function() {
+    text.UNICODE(undefined).should.equal(error.value);
+    text.UNICODE(error.na).should.equal(error.na);
     text.UNICODE('A').should.equal(65);
     text.UNICODE("Ϩ").should.equal(1000);
   });
 
   it('UPPER', function() {
+    text.UPPER(undefined).should.equal('');
+    text.UPPER(error.na).should.equal(error.na);
     text.UPPER('to upper case please').should.equal('TO UPPER CASE PLEASE');
     text.UPPER(true).should.equal(error.value);
   });


### PR DESCRIPTION
I matched behaviour of selected functions with Excel when undefined or error is passed as an argument. I haven't done this for all functions, but I tried to select these that I thought would be the most commonly used.

Related: #47, #48