### PR TITLE
[lib/statistical] Improve Excel parity for undefined, null & error inputs

### DIFF
--- a/lib/statistical.js
+++ b/lib/statistical.js
@@ -27,7 +27,7 @@ exports.AVERAGE = function() {
   if (flatArgumentsDefined.length === 0) {
     return error.div0;
   }
-  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArgumentsDefined);
   if (someError) {
     return someError;
   }
@@ -56,7 +56,7 @@ exports.AVERAGEA = function() {
   if (flatArgumentsDefined.length === 0) {
     return error.div0;
   }
-  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArgumentsDefined);
   if (someError) {
     return someError;
   }
@@ -454,7 +454,7 @@ exports.CORREL = function(array1, array2) {
 
 exports.COUNT = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -463,7 +463,7 @@ exports.COUNT = function() {
 
 exports.COUNTA = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -486,7 +486,7 @@ exports.COUNTIN = function (range, value) {
 
 exports.COUNTBLANK = function() {
   var range = utils.flatten(arguments);
-  var someError = range.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, range);
   if (someError) {
     return someError;
   }
@@ -503,7 +503,7 @@ exports.COUNTBLANK = function() {
 
 exports.COUNTIF = function(range, criteria) {
   range = utils.flatten(range);
-  var someError = range.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, range);
   if (someError) {
     return someError;
   }
@@ -538,7 +538,7 @@ exports.COUNTIFS = function() {
   }
   for (i = 0; i < args.length; i += 2) {
     var range = utils.flatten(args[i]);
-    var someError = range.find(function (arg) { return arg instanceof Error; });
+    var someError = utils.anyError.apply(undefined, range);
     if (someError) {
       return someError;
     }
@@ -1084,7 +1084,7 @@ exports.LOGNORM.INV = function(probability, mean, sd) {
 
 exports.MAX = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -1094,7 +1094,7 @@ exports.MAX = function() {
 
 exports.MAXA = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -1105,7 +1105,7 @@ exports.MAXA = function() {
 
 exports.MEDIAN = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -1121,7 +1121,7 @@ exports.MEDIAN = function() {
 
 exports.MIN = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }
@@ -1131,7 +1131,7 @@ exports.MIN = function() {
 
 exports.MINA = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  var someError = utils.anyError.apply(undefined, flatArguments);
   if (someError) {
     return someError;
   }

--- a/lib/statistical.js
+++ b/lib/statistical.js
@@ -9,7 +9,12 @@ var misc = require('./miscellaneous');
 var SQRT2PI = 2.5066282746310002;
 
 exports.AVEDEV = function() {
-  var range = utils.parseNumberArray(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(utils.isDefined);
+  if (flatArgumentsDefined.length === 0) {
+    return error.num;
+  }
+  var range = utils.parseNumberArray(flatArgumentsDefined);
   if (range instanceof Error) {
     return range;
   }
@@ -17,7 +22,16 @@ exports.AVEDEV = function() {
 };
 
 exports.AVERAGE = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(utils.isDefined);
+  if (flatArgumentsDefined.length === 0) {
+    return error.div0;
+  }
+  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArgumentsDefined);
   var n = range.length;
   var sum = 0;
   var count = 0;
@@ -37,7 +51,16 @@ exports.AVERAGE = function() {
 };
 
 exports.AVERAGEA = function() {
-  var range = utils.flatten(arguments);
+  var flatArguments = utils.flatten(arguments);
+  var flatArgumentsDefined = flatArguments.filter(utils.isDefined);
+  if (flatArgumentsDefined.length === 0) {
+    return error.div0;
+  }
+  var someError = flatArgumentsDefined.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = flatArgumentsDefined;
   var n = range.length;
   var sum = 0;
   var count = 0;
@@ -68,8 +91,11 @@ exports.AVERAGEIF = function(range, criteria, average_range) {
     return error.na;
   }
   average_range = average_range || range;
+  var flatAverageRange = utils.flatten(average_range);
+  var flatAverageRangeDefined = flatAverageRange.filter(utils.isDefined);
+  average_range = utils.parseNumberArray(flatAverageRangeDefined);
+
   range = utils.flatten(range);
-  average_range = utils.parseNumberArray(utils.flatten(average_range));
 
   if (average_range instanceof Error) {
     return average_range;
@@ -100,7 +126,7 @@ exports.AVERAGEIF = function(range, criteria, average_range) {
 
 exports.AVERAGEIFS = function() {
   // Does not work with multi dimensional ranges yet!
-  //http://office.microsoft.com/en-001/excel-help/averageifs-function-HA010047493.aspx
+  // http://office.microsoft.com/en-001/excel-help/averageifs-function-HA010047493.aspx
   var args = utils.argsToArray(arguments);
   var criteriaLength = (args.length - 1) / 2;
   var range = utils.flatten(args[0]);
@@ -427,12 +453,21 @@ exports.CORREL = function(array1, array2) {
 };
 
 exports.COUNT = function() {
-  return utils.numbers(utils.flatten(arguments)).length;
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  return utils.numbers(flatArguments).length;
 };
 
 exports.COUNTA = function() {
-  var range = utils.flatten(arguments);
-  return range.length - exports.COUNTBLANK(range);
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  return flatArguments.length - exports.COUNTBLANK(flatArguments);
 };
 
 exports.COUNTIN = function (range, value) {
@@ -451,11 +486,15 @@ exports.COUNTIN = function (range, value) {
 
 exports.COUNTBLANK = function() {
   var range = utils.flatten(arguments);
+  var someError = range.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
   var blanks = 0;
   var element;
   for (var i = 0; i < range.length; i++) {
     element = range[i];
-    if (element === null || element === '') {
+    if (element === undefined || element === null || element === '') {
       blanks++;
     }
   }
@@ -464,6 +503,10 @@ exports.COUNTBLANK = function() {
 
 exports.COUNTIF = function(range, criteria) {
   range = utils.flatten(range);
+  var someError = range.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
 
   var isWildcard = criteria === void 0 || criteria === '*';
 
@@ -495,6 +538,10 @@ exports.COUNTIFS = function() {
   }
   for (i = 0; i < args.length; i += 2) {
     var range = utils.flatten(args[i]);
+    var someError = range.find(function (arg) { return arg instanceof Error; });
+    if (someError) {
+      return someError;
+    }
     var criteria = args[i + 1];
     var isWildcard = criteria === void 0 || criteria === '*';
 
@@ -1036,17 +1083,33 @@ exports.LOGNORM.INV = function(probability, mean, sd) {
 };
 
 exports.MAX = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArguments);
   return (range.length === 0) ? 0 : Math.max.apply(Math, range);
 };
 
 exports.MAXA = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
+  range = range.map(function (value) { return (value === undefined || value === null) ? 0 : value; });
   return (range.length === 0) ? 0 : Math.max.apply(Math, range);
 };
 
 exports.MEDIAN = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
   var result = jStat.median(range);
 
   if (isNaN(result)) {
@@ -1057,12 +1120,23 @@ exports.MEDIAN = function() {
 };
 
 exports.MIN = function() {
-  var range = utils.numbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.numbers(flatArguments);
   return (range.length === 0) ? 0 : Math.min.apply(Math, range);
 };
 
 exports.MINA = function() {
-  var range = utils.arrayValuesToNumbers(utils.flatten(arguments));
+  var flatArguments = utils.flatten(arguments);
+  var someError = flatArguments.find(function (arg) { return arg instanceof Error; });
+  if (someError) {
+    return someError;
+  }
+  var range = utils.arrayValuesToNumbers(flatArguments);
+  range = range.map(function (value) { return (value === undefined || value === null) ? 0 : value; });
   return (range.length === 0) ? 0 : Math.min.apply(Math, range);
 };
 

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -216,6 +216,10 @@ exports.anyError = function() {
   return undefined;
 };
 
+exports.isDefined = function (arg) {
+  return arg !== undefined && arg !== null;
+};
+
 exports.anyIsError = function() {
   var n = arguments.length;
   while (n--) {

--- a/test/statistical.js
+++ b/test/statistical.js
@@ -6,6 +6,9 @@ var should = require('should');
 
 describe('Statistical', function() {
   it("AVEDEV", function() {
+    statistical.AVEDEV(undefined).should.equal(error.num);
+    statistical.AVEDEV(2, undefined, undefined).should.equal(0);
+    statistical.AVEDEV(error.na).should.equal(error.na);
     statistical.AVEDEV(2, 4, 8, 16).should.approximately(4.5, 1e-9);
     statistical.AVEDEV([2, 4, 8, 16]).should.approximately(4.5, 1e-9);
     statistical.AVEDEV([2, 4], [8, 16]).should.approximately(4.5, 1e-9);
@@ -17,6 +20,9 @@ describe('Statistical', function() {
   });
 
   it("AVERAGE", function() {
+    statistical.AVERAGE(undefined).should.equal(error.div0);
+    statistical.AVERAGE(2, undefined, undefined).should.equal(2);
+    statistical.AVERAGE(error.na).should.equal(error.na);
     statistical.AVERAGE(2, 4, 8, 16).should.approximately(7.5, 1e-9);
     statistical.AVERAGE([2, 4, 8, 16]).should.approximately(7.5, 1e-9);
     statistical.AVERAGE([2, 4], [8, 16]).should.approximately(7.5, 1e-9);
@@ -32,6 +38,9 @@ describe('Statistical', function() {
   });
 
   it("AVERAGEA", function() {
+    statistical.AVERAGEA(undefined).should.equal(error.div0);
+    statistical.AVERAGEA(2, undefined, undefined).should.equal(2);
+    statistical.AVERAGEA(error.na).should.equal(error.na);
     statistical.AVERAGEA(2, 4, 8, 16).should.approximately(7.5, 1e-9);
     statistical.AVERAGEA([2, 4, 8, 16]).should.approximately(7.5, 1e-9);
     statistical.AVERAGEA([2, 4], [8, 16]).should.approximately(7.5, 1e-9);
@@ -40,6 +49,7 @@ describe('Statistical', function() {
   });
 
   it("AVERAGEIF", function() {
+    statistical.AVERAGEIF([undefined], '>5').should.equal(error.value); // different than Excel
     statistical.AVERAGEIF([2, 4, 8, 16], '>5').should.equal(12);
     statistical.AVERAGEIF([2, 4, 8, 16], '*').should.equal(7.5);
     statistical.AVERAGEIF([2, 4, 8, 16], '>5', [1, 2, 3, 4]).should.approximately(3.5, 1e-9);
@@ -166,6 +176,8 @@ describe('Statistical', function() {
 
   it("COUNT", function() {
     statistical.COUNT().should.equal(0);
+    statistical.COUNT(undefined).should.equal(0);
+    statistical.COUNT(error.na).should.equal(error.na);
     statistical.COUNT(1, 2, 3, 4).should.equal(4);
     statistical.COUNT([1, 2, 3, 4]).should.equal(4);
     statistical.COUNT([1, 2], [3, 4]).should.equal(4);
@@ -187,6 +199,8 @@ describe('Statistical', function() {
 
   it("COUNTA", function() {
     statistical.COUNTA().should.equal(0);
+    statistical.COUNTA(undefined).should.equal(0);
+    statistical.COUNTA(error.na).should.equal(error.na);
     statistical.COUNTA(1, null, 3, 'a', '', 'c').should.equal(4);
     statistical.COUNTA([1, null, 3, 'a', '', 'c']).should.equal(4);
     statistical.COUNTA([1, null, 3], ['a', '', 'c']).should.equal(4);
@@ -198,6 +212,8 @@ describe('Statistical', function() {
 
   it("COUNTBLANK", function() {
     statistical.COUNTBLANK().should.equal(0);
+    statistical.COUNTBLANK(undefined).should.equal(1);
+    statistical.COUNTBLANK(error.na).should.equal(error.na);
     statistical.COUNTBLANK(1, null, 3, 'a', '', 'c').should.equal(2);
     statistical.COUNTBLANK([1, null, 3, 'a', '', 'c']).should.equal(2);
     statistical.COUNTBLANK([1, null, 3], ['a', '', 'c']).should.equal(2);
@@ -208,6 +224,8 @@ describe('Statistical', function() {
   });
 
   it("COUNTIF", function() {
+    statistical.COUNTIF([undefined], '>1').should.equal(0);
+    statistical.COUNTIF([error.na], '>1').should.equal(error.na);
     statistical.COUNTIF([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIF([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIF([
@@ -225,6 +243,8 @@ describe('Statistical', function() {
   });
 
   it("COUNTIFS", function() {
+    statistical.COUNTIFS([undefined], '>1').should.equal(0);
+    statistical.COUNTIFS([error.na], '>1').should.equal(error.na);
     statistical.COUNTIFS([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIFS([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIFS([
@@ -526,6 +546,8 @@ describe('Statistical', function() {
 
   it("MAX", function() {
     statistical.MAX().should.equal(0);
+    statistical.MAX(undefined).should.equal(0);
+    statistical.MAX(error.na).should.equal(error.na);
     statistical.MAX([0.1, 0.2], [0.4, 0.8], [true, false]).should.approximately(0.8, 1e-9);
     statistical.MAX([
       [0, 0.1, 0.2],
@@ -536,6 +558,8 @@ describe('Statistical', function() {
 
   it("MAXA", function() {
     statistical.MAXA().should.equal(0);
+    statistical.MAXA(undefined).should.equal(0);
+    statistical.MAXA(error.na).should.equal(error.na);
     statistical.MAXA([0.1, 0.2], [0.4, 0.8], [true, false]).should.equal(1);
     statistical.MAXA([
       [0.1, 0.2],
@@ -546,12 +570,16 @@ describe('Statistical', function() {
 
   it('MEDIAN', function() {
     statistical.MEDIAN().should.equal(error.num);
+    statistical.MEDIAN(undefined).should.equal(error.num);
+    statistical.MEDIAN(error.na).should.equal(error.na);
     statistical.MEDIAN(1, 2, 3, 4, 5).should.equal(3);
     statistical.MEDIAN(1, 2, 3, 4, 5, 6).should.approximately(3.5, 1e-9);
   });
 
   it("MIN", function() {
     statistical.MIN().should.equal(0);
+    statistical.MIN(undefined).should.equal(0);
+    statistical.MIN(error.na).should.equal(error.na);
     statistical.MIN([0.1, 0.2], [0.4, 0.8], [true, false]).should.approximately(0.1, 1e-9);
     statistical.MIN([0, 0.1, 0.2], [0.4, 0.8, 1], [true, false]).should.equal(0);
     statistical.MIN([
@@ -568,6 +596,8 @@ describe('Statistical', function() {
 
   it("MINA", function() {
     statistical.MINA().should.equal(0);
+    statistical.MINA(undefined).should.equal(0);
+    statistical.MINA(error.na).should.equal(error.na);
     statistical.MINA([0.1, 0.2], [0.4, 0.8], [true, false]).should.equal(0);
     statistical.MINA([
       [10, 0],


### PR DESCRIPTION
Scope: lib/statistical.js

There's some duplication of "if anyError return error" - I could pull these into `utils.number` and `utils.arrayValuesToNumbers` but wasn't sure that's a good idea. Let me know.

In case this comes up - I couldn't use `anyIsError` because jshint complains about spread operator... This might be a separate conversation - feels like the code is attempting compatibility with a very old ES version.