### PR TITLE
fix: COUNT* functions don't propagate errors

### DIFF
--- a/lib/statistical.js
+++ b/lib/statistical.js
@@ -454,19 +454,11 @@ exports.CORREL = function(array1, array2) {
 
 exports.COUNT = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = utils.anyError.apply(undefined, flatArguments);
-  if (someError) {
-    return someError;
-  }
   return utils.numbers(flatArguments).length;
 };
 
 exports.COUNTA = function() {
   var flatArguments = utils.flatten(arguments);
-  var someError = utils.anyError.apply(undefined, flatArguments);
-  if (someError) {
-    return someError;
-  }
   return flatArguments.length - exports.COUNTBLANK(flatArguments);
 };
 
@@ -486,10 +478,6 @@ exports.COUNTIN = function (range, value) {
 
 exports.COUNTBLANK = function() {
   var range = utils.flatten(arguments);
-  var someError = utils.anyError.apply(undefined, range);
-  if (someError) {
-    return someError;
-  }
   var blanks = 0;
   var element;
   for (var i = 0; i < range.length; i++) {
@@ -503,10 +491,6 @@ exports.COUNTBLANK = function() {
 
 exports.COUNTIF = function(range, criteria) {
   range = utils.flatten(range);
-  var someError = utils.anyError.apply(undefined, range);
-  if (someError) {
-    return someError;
-  }
 
   var isWildcard = criteria === void 0 || criteria === '*';
 
@@ -538,10 +522,6 @@ exports.COUNTIFS = function() {
   }
   for (i = 0; i < args.length; i += 2) {
     var range = utils.flatten(args[i]);
-    var someError = utils.anyError.apply(undefined, range);
-    if (someError) {
-      return someError;
-    }
     var criteria = args[i + 1];
     var isWildcard = criteria === void 0 || criteria === '*';
 

--- a/test/statistical.js
+++ b/test/statistical.js
@@ -177,8 +177,9 @@ describe('Statistical', function() {
   it("COUNT", function() {
     statistical.COUNT().should.equal(0);
     statistical.COUNT(undefined).should.equal(0);
-    statistical.COUNT(error.na).should.equal(error.na);
+    statistical.COUNT(error.na).should.equal(0);
     statistical.COUNT(1, 2, 3, 4).should.equal(4);
+    statistical.COUNT(1, 2, error.div0, 4).should.equal(3);
     statistical.COUNT([1, 2, 3, 4]).should.equal(4);
     statistical.COUNT([1, 2], [3, 4]).should.equal(4);
     statistical.COUNT([
@@ -200,7 +201,8 @@ describe('Statistical', function() {
   it("COUNTA", function() {
     statistical.COUNTA().should.equal(0);
     statistical.COUNTA(undefined).should.equal(0);
-    statistical.COUNTA(error.na).should.equal(error.na);
+    statistical.COUNTA(error.na).should.equal(1);
+    statistical.COUNTA(1, 2, error.div0).should.equal(3);
     statistical.COUNTA(1, null, 3, 'a', '', 'c').should.equal(4);
     statistical.COUNTA([1, null, 3, 'a', '', 'c']).should.equal(4);
     statistical.COUNTA([1, null, 3], ['a', '', 'c']).should.equal(4);
@@ -213,7 +215,8 @@ describe('Statistical', function() {
   it("COUNTBLANK", function() {
     statistical.COUNTBLANK().should.equal(0);
     statistical.COUNTBLANK(undefined).should.equal(1);
-    statistical.COUNTBLANK(error.na).should.equal(error.na);
+    statistical.COUNTBLANK(error.na).should.equal(0);
+    statistical.COUNTBLANK(1, 2, error.div0).should.equal(0);
     statistical.COUNTBLANK(1, null, 3, 'a', '', 'c').should.equal(2);
     statistical.COUNTBLANK([1, null, 3, 'a', '', 'c']).should.equal(2);
     statistical.COUNTBLANK([1, null, 3], ['a', '', 'c']).should.equal(2);
@@ -225,7 +228,7 @@ describe('Statistical', function() {
 
   it("COUNTIF", function() {
     statistical.COUNTIF([undefined], '>1').should.equal(0);
-    statistical.COUNTIF([error.na], '>1').should.equal(error.na);
+    statistical.COUNTIF([error.na], '>1').should.equal(0);
     statistical.COUNTIF([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIF([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIF([
@@ -244,7 +247,7 @@ describe('Statistical', function() {
 
   it("COUNTIFS", function() {
     statistical.COUNTIFS([undefined], '>1').should.equal(0);
-    statistical.COUNTIFS([error.na], '>1').should.equal(error.na);
+    statistical.COUNTIFS([error.na], '>1').should.equal(0);
     statistical.COUNTIFS([1, null, 3, 'a', ''], '>1').should.equal(1);
     statistical.COUNTIFS([1, null, 'c', 'a', ''], '>1').should.equal(0);
     statistical.COUNTIFS([


### PR DESCRIPTION
This behaviour was incorrectly changed in f99c5e7. COUNT* functions don't follow the same behaviour as many other functions and they do not "break" on errors.