### PR TITLE
Fix NETWORKDAYS.INTL rounding error

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -381,7 +381,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
     }
     holidays[i] = h;
   }
-  var days = (end_date - start_date) / (1000 * 60 * 60 * 24) + 1;
+  var days = Math.round((end_date - start_date) / (1000 * 60 * 60 * 24)) + 1;
   var total = days;
   var day = start_date;
   for (i = 0; i < days; i++) {

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -358,7 +358,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
     isMask = true;
     weekend = weekend.split('');
     for (i = 0; i < weekend.length; i++) {
-      if (+weekend[i] === 1) {
+      if (weekend[i] === '1') {
         maskDays.push(maskIndex[i]);
       }
     }

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -358,7 +358,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
     isMask = true;
     weekend = weekend.split('');
     for (i = 0; i < weekend.length; i++) {
-      if (weekend[i] === 1) {
+      if (+weekend[i] === 1) {
         maskDays.push(maskIndex[i]);
       }
     }

--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -349,7 +349,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
   
   var isMask = false;
   var maskDays = [];
-  var maskIndex = [1, 2, 3, 4, 5, 6, 0]
+  var maskIndex = [1, 2, 3, 4, 5, 6, 0];
   var maskRegex = new RegExp('^[0|1]{7}$');
   
   if (weekend === undefined) {
@@ -358,7 +358,7 @@ exports.NETWORKDAYS.INTL = function (start_date, end_date, weekend, holidays) {
     isMask = true;
     weekend = weekend.split('');
     for (i = 0; i < weekend.length; i++) {
-      if (weekend[i] == 1) {
+      if (weekend[i] === 1) {
         maskDays.push(maskIndex[i]);
       }
     }

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -151,6 +151,7 @@ describe('Date & Time', function () {
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', 'smlkml').should.equal(error.value);
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '00011').should.equal(error.value);
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '0001101').should.equal(32);
+    dateTime.NETWORKDAYS.INTL('11/01/2021', '11/30/2021', "1110111").should.equal(4);
   });
 
   it('NOW', function () {

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -151,7 +151,7 @@ describe('Date & Time', function () {
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', 'smlkml').should.equal(error.value);
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '00011').should.equal(error.value);
     dateTime.NETWORKDAYS.INTL('1/1/2021', '2/24/2021', '0001101').should.equal(32);
-    dateTime.NETWORKDAYS.INTL('11/01/2021', '11/30/2021', "1110111").should.equal(4);
+    dateTime.NETWORKDAYS.INTL('11/01/2021', '11/30/2021', '1110111').should.equal(4);
   });
 
   it('NOW', function () {


### PR DESCRIPTION
[PR #33](https://github.com/formulajs/formulajs/pull/33) introduced using a sting mask values to return number of days between two dates.  However, in some cases, the value returned is incorrect due to rounding errors on the days calculation.  For example:

`NETWORKDAYS.INTL('11/01/2021', '11/30/2021', "1110111")` returns 3.041666666666668 whereas the answer should be 4.

Line calculating the days is:
https://github.com/formulajs/formulajs/blob/4c2badf97ea6500e5c27fecfb53672ad208c8afd/lib/date-time.js#L384

To fixed this, I suggest we improve the day calculation by rounding the result as follows:
`var days = Math.round((end_date - start_date) / (1000 * 60 * 60 * 24)) + 1;`