### PR TITLE
Use safer global replace in `SUBSTITUTE` (#72)

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -295,7 +295,7 @@ exports.SUBSTITUTE = function(text, old_text, new_text, occurrence) {
   if (!text || !old_text) {
     return text;
   } else if (occurrence === undefined) {
-    return text.replace(new RegExp(old_text, 'g'), new_text);
+    return text.split(old_text).join(new_text);
   } else {
     var index = 0;
     var i = 0;

--- a/test/text.js
+++ b/test/text.js
@@ -246,6 +246,7 @@ describe('Text', function() {
   it("SUBSTITUTE", function() {
     text.SUBSTITUTE('Jim Alateras', 'im', 'ames').should.equal("James Alateras");
     text.SUBSTITUTE('Jim Alateras', '', 'ames').should.equal("Jim Alateras");
+    text.SUBSTITUTE('J. Alateras', '.', 'ames').should.equal("James Alateras");
     text.SUBSTITUTE('Jim Alateras', undefined, 'ames').should.equal("Jim Alateras");
     text.SUBSTITUTE('', 'im', 'ames').should.equal("");
     should.not.exist(text.SUBSTITUTE(undefined, 'im', 'ames'));


### PR DESCRIPTION
Resolves https://github.com/formulajs/formulajs/issues/72

NOTE: This is a breaking change for anyone that expects regex meta characters to be interpreted.