### PR TITLE
Fix Days360 optional argument

### DIFF
--- a/lib/date-time.js
+++ b/lib/date-time.js
@@ -188,7 +188,7 @@ exports.DAYS = function (end_date, start_date) {
 };
 
 exports.DAYS360 = function (start_date, end_date, method) {
-  method = utils.parseBool(method);
+  method = utils.parseBool(method || 'false');
   start_date = utils.parseDate(start_date);
   end_date = utils.parseDate(end_date);
 

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -93,7 +93,9 @@ describe('Date & Time', function () {
     dateTime.DAYS360('1/1/1901', '1/1/1902', true).should.equal(360);
     dateTime.DAYS360('1/1/1901', '2/1/1901', true).should.equal(30);
     dateTime.DAYS360('1/1/1901', '1/2/1901', false).should.equal(1);
+    dateTime.DAYS360('1/1/1901', '1/2/1901').should.equal(1);
     dateTime.DAYS360('1/1/1901', '12/31/1901', false).should.equal(360);
+    dateTime.DAYS360('1/1/1901', '12/31/1901').should.equal(360);
     dateTime.DAYS360('1/1/1901', '1/1/1902', false).should.equal(360);
     dateTime.DAYS360('1/1/1901', '2/1/1901', false).should.equal(30);
     dateTime.DAYS360('1/30/1901', '12/31/1901', false).should.equal(330);


### PR DESCRIPTION
## Summary

fixes #80

The 3rd argument for DAYS360 should be optional for excel parity.

https://support.microsoft.com/en-us/office/days360-function-b9a509fd-49ef-407e-94df-0cbda5718c2a