### PR TITLE
Fix Exact is always true

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -79,12 +79,12 @@ exports.EXACT = function(text1, text2) {
   if (arguments.length !== 2) {
     return error.na;
   }
-  var someError = utils.anyError(text1, text1);
+  var someError = utils.anyError(text1, text2);
   if (someError) {
     return someError;
   }
-  text1 = utils.toString(text1);
-  text2 = utils.toString(text2);
+  text1 = utils.parseString(text1);
+  text2 = utils.parseString(text2);
   return text1 === text2;
 };
 

--- a/test/text.js
+++ b/test/text.js
@@ -74,10 +74,12 @@ describe('Text', function() {
     text.EXACT(undefined, "").should.equal(true);
     text.EXACT(error.na, error.na).should.equal(error.na);
     text.EXACT('yes', 'yes').should.equal(true);
+    text.EXACT('yes', 'no').should.equal(false);
     text.EXACT('yes', 'yes', 'yes').should.equal(error.na);
     text.EXACT().should.equal(error.na);
     text.EXACT('true', true).should.equal(true);
     text.EXACT('12', 12).should.equal(true);
+    text.EXACT('Word', '0').should.equal(false);
   });
 
   it('FIND', function() {
@@ -361,7 +363,7 @@ describe('Text', function() {
 
     /**
      * Only supports thousands separator "," and decimal separator "."
-     * 
+     *
      * These separators are not yet configurable. But the aim is not be as extensive as dedicated parsing library
      * such as Numeral.js or Numbro.
      */


### PR DESCRIPTION
## Summary

fixes #81

`utils.toString` is converting nearly everything to `[Object object]` -- even undefined and null.  

`utils.parseString` seems like the more appropriate utility:

https://github.com/formulajs/formulajs/blob/5c033102658d86f34cee89b6edd77959c225651d/lib/utils/common.js#L122-L131
