### PR TITLE
Feature: Implement CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ var { SUM } = require('@formulajs/formulajs') // require individual components
 SUM([1, 2, 3]) // 6
 ```
 
+### Command Line Interface (CLI)
+
+When Formula.js is installed globally using npm, it can be used from the command line. To install Formula.js globally:
+
+```
+npm i -g @formulajs/formulajs
+```
+
+After installation, Formula.js is available via the command line:
+
+```sh
+$ formulajs
+> SUM(1,2,3)
+6
+```
+
 ## Differences between Excel functions and Formula.js
 
 ### Date

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+// eslint-disable-next-line no-unused-vars
+import * as formulajs from '../lib/esm/index.mjs'
+import * as readline from 'readline'
+
+function runStream(input, output) {
+  const rl = readline.createInterface({
+    input: input || process.stdin,
+    output: output || process.stdout
+  })
+
+  if (rl.output.isTTY) {
+    rl.setPrompt('> ')
+    rl.prompt()
+  }
+
+  rl.on('line', (line) => {
+    const expr = line.trim()
+
+    switch (expr.toLowerCase()) {
+      case 'quit':
+      case 'exit':
+        rl.close()
+        break
+      case 'clear':
+        if (rl.output.isTTY) {
+          rl.prompt()
+        }
+        break
+      default:
+        if (!expr) {
+          break
+        }
+
+        try {
+          let result = eval('formulajs.' + expr)
+          console.log(result)
+        } catch (err) {
+          console.log(err.toString())
+        }
+        break
+    }
+
+    if (rl.output.isTTY) {
+      rl.prompt()
+    }
+  })
+
+  rl.on('close', () => {
+    console.log()
+    process.exit(0)
+  })
+}
+
+runStream(process.stdin, process.stdout)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   },
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "formulajs": "./bin/cli.js"
+  },
   "main": "./lib/cjs",
   "module": "./lib/esm",
   "unpkg": "./lib/browser/formula.min.js",
@@ -25,6 +28,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "bin/cli.js",
     "lib"
   ],
   "scripts": {


### PR DESCRIPTION
Adds command line interface (CLI) to Formula.js.

When Formula.js is installed globally using npm (`npm install -g @formulajs/formulajs`), formulas can be used from the command line:
```sh
$ formulajs
> SUM(1,2,3)
6
```