### PR TITLE
Fix: Timezone dependence during tests

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -202,15 +202,15 @@ function serialNumberToDate(serial) {
 
   const hours = Math.floor(total_seconds / (60 * 60))
   const minutes = Math.floor(total_seconds / 60) % 60
-  let days = date_info.getDate()
-  let month = date_info.getMonth()
+  let days = date_info.getUTCDate()
+  let month = date_info.getUTCMonth()
 
   if (serial >= 60 && serial < 61) {
     days = 29
     month = 1
   }
 
-  return new Date(date_info.getFullYear(), month, days, hours, minutes, seconds)
+  return new Date(date_info.getUTCFullYear(), month, days, hours, minutes, seconds)
 }
 
 export function parseDate(date) {
@@ -229,7 +229,7 @@ export function parseDate(date) {
   }
 
   if (typeof date === 'string') {
-    date = new Date(date)
+    date = date.match(/(\d{4})-(\d\d?)-(\d\d?)$/) ? new Date(date + 'T00:00:00.000') : new Date(date)
 
     if (!isNaN(date)) {
       return date

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -229,7 +229,7 @@ export function parseDate(date) {
   }
 
   if (typeof date === 'string') {
-    date = date.match(/(\d{4})-(\d\d?)-(\d\d?)$/) ? new Date(date + 'T00:00:00.000') : new Date(date)
+    date = /(\d{4})-(\d\d?)-(\d\d?)$/.test(date) ? new Date(date + 'T00:00:00.000') : new Date(date)
 
     if (!isNaN(date)) {
       return date

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,1 @@
-process.env.TZ = 'Europe/Amsterdam'
-
 import '../src/index.js'


### PR DESCRIPTION
Hi @nicolashefti,
I tried to take a stab at this [pesky timezone issue](https://github.com/formulajs/formulajs/issues/85).  I came up with a fix that works but feels a bit hacky.

Dates in test cases are either `yyyy-mm-dd` or `mm/dd/yyyy` format.  Unfortunately, since `new Date()` creates a date object in user's local timezone, this creates issues.  For example, since I am near Los Angeles, the following dates give different results.
```javascript
new Date('2007-01-01')  // Sun Dec 31 2006 16:00:00 GMT-0800 (Pacific Standard Time)
```
```javascript
new Date('1/1/2007')  // Mon Jan 01 2007 00:00:00 GMT-0800 (Pacific Standard Time)
```

In order to address this, I decided to modify the date string if it matched the format` yyyy-mm-dd`, by adding `T00:00:00.000`:
https://github.com/formulajs/formulajs/blob/8835f778120ca6008ab056e8a104abab9e5e6ee6/src/utils/common.js#L232 because following is timezone independent:
```javasript
new Date('2007-01-01T00:00:00.000')  // Mon Jan 01 2007 00:00:00 GMT-0800 (Pacific Standard Time)
```
I also changed the date returned by `serialNumberToDate()` function to UTC time:
https://github.com/formulajs/formulajs/blob/8835f778120ca6008ab056e8a104abab9e5e6ee6/src/utils/common.js#L205-L206
https://github.com/formulajs/formulajs/blob/8835f778120ca6008ab056e8a104abab9e5e6ee6/src/utils/common.js#L213

I can't guarantee there won't be any edge cases, but I tested using several [timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) and all unit-tests pass.  I know Formula.js is not a date parsing library and adding an external library such as Moment.js (or now Luxon) may not be practical, maybe this would be a good patch?  Let me know what you think.