### PR TITLE
Partially created TEXT formula

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@formulajs/formulajs",
-  "version": "3.1.5",
+  "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@formulajs/formulajs",
-      "version": "3.1.5",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "bessel": "^1.0.2",
+        "decimal.js": "^10.4.3",
         "jstat": "^1.9.5"
       },
       "bin": {
@@ -2479,6 +2480,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -6968,6 +6974,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "deep-is": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "bessel": "^1.0.2",
+    "decimal.js": "^10.4.3",
     "jstat": "^1.9.5"
   },
   "devDependencies": {

--- a/src/text.js
+++ b/src/text.js
@@ -1,5 +1,6 @@
 import * as error from './utils/error.js'
 import * as utils from './utils/common.js'
+import Decimal from 'decimal.js';
 
 // TODO
 /**
@@ -628,18 +629,164 @@ export function T(value) {
   return typeof value === 'string' ? value : ''
 }
 
-// TODO incomplete implementation
+function handleTextNumbers(value, format_text) {
+  let result = ""
+  const integers = value.toString().split(".")[0] || ""
+  const decimals = value.toString().split(".")[1] || ""
+  let currentValueIndex = 0
+  let currentIntegerIndex = 0
+  let currentDecimalIndex = 0
+  let isInteger = true
+
+  const numberOfHashesAndZerosBeforeDecimal = format_text.split(".")[0].match(/[0|#]/g)?.length || 0
+  const numberOfHashesAndZerosAfterDecimal = format_text.split(".")?.[1]?.match(/[0|#]/g)?.length || 0
+  const endOfDecimalIndex = Math.min(decimals.length, numberOfHashesAndZerosAfterDecimal) - 1
+
+  for (let i = 0; i < format_text.length; i++) {
+    if (format_text[i] === "#" || format_text[i] === "0") {
+      // integer portion of the number
+      if (isInteger && currentIntegerIndex < integers.length) {
+        // even if the number of hashes and zeros is less than the number of integers, we still need to show all the integers
+        if (currentIntegerIndex === 0 && numberOfHashesAndZerosBeforeDecimal < integers.length) {
+          const addToIndexes = integers.length - numberOfHashesAndZerosBeforeDecimal + 1
+          const shouldRound = addToIndexes === integers.length && !numberOfHashesAndZerosAfterDecimal
+
+          if (shouldRound) {
+            result += Math.round(value).toString().substring(0, addToIndexes)
+          }
+          else {
+            result += integers.substring(0, addToIndexes)
+          }
+
+          currentValueIndex += addToIndexes
+          currentIntegerIndex += addToIndexes
+        }
+        // replace the hash or zero with the associated integer
+        else {
+          const shouldRound = currentIntegerIndex === integers.length - 1 && !numberOfHashesAndZerosAfterDecimal
+          if (shouldRound) {
+            result += Math.round(value).toString().substr(-1)
+          }
+          else {
+            result += value.toString()[currentValueIndex]
+          }
+
+          currentValueIndex++
+          currentIntegerIndex++
+        }
+      }
+      // decimal portion of the number
+      else if (!isInteger && currentDecimalIndex < endOfDecimalIndex + 1) {
+        const shouldRound = currentDecimalIndex === endOfDecimalIndex
+        if (shouldRound) {
+          result += value.toFixed(currentDecimalIndex + 1).toString().substr(-1)
+        } else {
+          result += value.toString()[currentValueIndex]
+        }
+
+        currentValueIndex++
+        currentDecimalIndex++
+      }
+    }
+    // decimal point
+    else if (format_text[i] === ".") {
+      isInteger = false
+      if (currentIntegerIndex <= integers.length) {
+        result += integers.substring(currentIntegerIndex)
+        currentValueIndex = integers.length + 1
+        currentIntegerIndex = integers.length
+      }
+      result += "."
+    }
+
+    // other random characters, e.g. xx, $, etc.
+    else {
+      result += format_text[i]
+    }
+  }
+
+  return result;
+}
+
 /**
- * -- Not implemented --
+ * -- Partially implemented --
+ *
+ * The following are not supported:
+ * - Scientific notation
+ * - Leading and trailing zeros
+ * - Some special formats like "[<=9999999]###-####;(###) ###-####", "###° 00' 00''"
+ * - Fractions
+ * - Dates and times
+ * - Some accounting formats
+ * - Thousands separator
  *
  * Formats a number and converts it to text.
  *
  * Category: Text
- *
+ * @params {*} value A numeric value that you want to be converted into text.
+ * @params {*} format_text A text string that defines the formatting that you want to be applied to the supplied value.
  * @returns
  */
-export function TEXT() {
-  throw new Error('TEXT is not implemented')
+export function TEXT(value, format_text) {
+  if (value === undefined || format_text === undefined) {
+    return error.na;
+  }
+
+  value = utils.parseNumber(value);
+  if (utils.anyIsError(value)) {
+    return error.value
+  }
+
+  format_text = utils.parseString(format_text);
+  if (utils.anyIsError("FORMAT: ", format_text)) {
+    return error.value;
+  }
+
+  let result = "";
+  if (format_text === "") {
+    result = format_text
+  }
+  else if (
+    format_text.includes("#,") ||
+    format_text.includes("0,") ||
+    format_text.includes("h") ||
+    format_text.includes("m") ||
+    format_text.includes("s") ||
+    format_text.includes("d") ||
+    format_text.includes("y") ||
+    format_text.includes("A/P") ||
+    format_text.includes("AM/PM") ||
+    format_text.includes("?/") ||
+    format_text.includes("/?") ||
+    format_text.includes("E+") ||
+    format_text.includes("E-") ||
+    format_text.includes("e+") ||
+    format_text.includes("e-") ||
+    format_text.includes("*") ||
+    format_text.includes("_") ||
+    format_text.includes(";") ||
+    format_text.includes("[") ||
+    format_text.includes("]")
+  ) {
+    throw new Error("TEXT formula not implemented")
+  }
+  // percentage
+  else if (format_text.includes("%")) {
+    if (format_text.length === 1) {
+      return format_text
+    }
+    const percentage = new Decimal(value).times(100).toNumber()
+    result = handleTextNumbers(percentage, format_text)
+  }
+  // general
+  else if (format_text.includes("#") || format_text.includes("0")) {
+    result = handleTextNumbers(new Decimal(value).toNumber(), format_text)
+  }
+  else {
+    throw new Error("TEXT formula not implemented")
+  }
+
+  return result
 }
 
 /**

--- a/test/text.js
+++ b/test/text.js
@@ -296,11 +296,129 @@ describe('Text', () => {
     text.T(true).should.equal('')
   })
 
-  xit('TEXT', () => {
+  it.only('TEXT', () => {
+    text.TEXT().should.equal(error.na)
+    text.TEXT('value').should.equal(error.na)
+    text.TEXT("VALUE", "").should.equal(error.value)
+    text.TEXT(12, "").should.equal("")
+
+    // percentage
+    text.TEXT("0.244740088392962", "0%").should.equal("24%")
+    text.TEXT("1.2555", "0%").should.equal("126%")
+    text.TEXT("1.2555", "########.##########%").should.equal("125.55%")
+    text.TEXT("0.244740088392962", "0.0%").should.equal("24.5%")
+    text.TEXT("0.244740088392962", "0.00%").should.equal("24.47%")
+    text.TEXT("0.244740088392962", ".%").should.equal("24.%")
+    text.TEXT("0.244740088392962", ".0%").should.equal("24.5%")
+    text.TEXT("0.244740088392962", "%").should.equal("%")
+    text.TEXT("0.244740088392962", "0.#%").should.equal("24.5%")
+    text.TEXT("0.244740088392962", "%").should.equal("%")
+    text.TEXT("0.244740088392962", " .x.%").should.equal(" 24.x.%")
+    text.TEXT("0.244740088392962", "0 # %").should.equal("2 4 %")
+    text.TEXT(1.244740088392962, "0 # %").should.equal("12 4 %")
+    text.TEXT("1", "0 # %").should.equal("10 0 %")
+
+    // // thousands separator
+    // text.TEXT('122000000', '#,###').should.equal('122,000,000')
+    // text.TEXT('122000000', '0,000.00').should.equal('122,000,000.00')
+    // text.TEXT('122000000', '#,').should.equal('12200')
+    // text.TEXT('122000000', '#,###.0,').should.equal('12,200.0')
+    // text.TEXT('122000000', '0.0,,').should.equal('12.2')
+    // text.TEXT(1234.56, '#,##0').should.equal('1,235') // thousands separator, no decimals
+    // text.TEXT(1234.56, '#,##0.00').should.equal('1,234.56') // thousands separator, 2 decimals
+
+    // number
+    text.TEXT(1234.56, '0.00').should.equal('1234.56') // general
     text.TEXT('1234.59', '###0.0').should.equal('1234.6')
     text.TEXT('1234.52', '###0.0').should.equal('1234.5')
     text.TEXT('1234.56', '###0.00').should.equal('1234.56')
-    text.TEXT().should.equal(error.na)
+
+    // currency
+    text.TEXT(1234.56, '$###0').should.equal('$1235')
+    text.TEXT(1234.56, '$###0.00').should.equal('$1234.56')
+    // text.TEXT(1234.56, '$#,##0').should.equal('$1,235') // no decimals
+    // text.TEXT(1234.56, '$#,##0.00').should.equal('$1,234.56') // 2 decimals
+    // text.TEXT(-1234.56, '$#,##0.00_);($#,##0.00)').should.equal('-$1,234.56') // 2 decimals, negative value
+    // text.TEXT(2800, "$#,###").should.equal("$2,800")
+
+    // // accounting
+    // text.TEXT(1234.56, '$ * #,##0').should.equal('$ 1,235') // no decimals
+    // text.TEXT(1234.56, '$ * #,##0.00').should.equal('$ 1,234.56') // 2 decimals
+    // text.TEXT(-1234.56, "_($* #,##0.00_);_($* (#,##0.00);_($* "-"??_);_(@_)").should.equal(error.value)
+
+    // // date - months
+    // text.TEXT("7/12/2022", "m").should.equal("12") // 1-12
+    // text.TEXT("7/12/2022", "mm").should.equal("12") // 01-12
+    // text.TEXT("7/12/2022", "mmm").should.equal("Dec") // Jan-Dec
+    // text.TEXT("7/12/2022", "mmmm").should.equal("December") // January-December
+    // text.TEXT("7/12/2022", "mmmmm").should.equal("D") // J-D
+
+    // // date - days
+    // text.TEXT("7/12/2022", "d").should.equal("7") // 1-31
+    // text.TEXT("7/12/2022", "dd").should.equal("07") // 01-31
+    // text.TEXT("7/12/2022", "ddd").should.equal("Wed") // Sun-Sat
+    // text.TEXT("7/12/2022", "dddd").should.equal("Wednesday") // Sunday-Saturday
+
+    // // date - years
+    // text.TEXT("7/12/2022", "yy").should.equal("22") // 00-99
+    // text.TEXT("7/12/2022", "yyyy").should.equal("2022") // 0000-9999
+
+    // // time - hours
+    // text.TEXT("10:38:00 am", "h").should.equal("10") // 0-23
+    // text.TEXT("10:38:00 am", "hh").should.equal("10") // 00-23
+
+    // // time - minutes
+    // text.TEXT("10:38:00 am", "m").should.equal("38") // 0-59
+    // text.TEXT("10:38:00 am", "mm").should.equal("38") // 00-59
+
+    // // time - seconds
+    // text.TEXT("10:38:00 am", "s").should.equal("0") // 0-59
+    // text.TEXT("10:38:00 am", "ss").should.equal("00") // 00-59
+
+    // // time - am/pm
+    // text.TEXT("10:38:00 am", "h AM/PM").should.equal("10 am")
+    // text.TEXT("10:38:00 am", "h:mm AM/PM").should.equal("10:38 am")
+    // text.TEXT("10:38:00 am", "h:mm:ss A/P").should.equal("10:38:00 A/P")
+    // text.TEXT("10:38:00 am", "h:mm:ss.00").should.equal("10:38:00.00")
+
+    // // time - elapsed time
+    // text.TEXT("1:02:16 am", "[h]:mm").should.equal("1:02") // hours and minutes
+    // text.TEXT("1:02:16 am", "[mm]:ss").should.equal("62:16") // minutes and seconds
+    // text.TEXT("1:02:16 am", "[ss].00").should.equal("3736.00") // seconds and hundredths
+
+    // // date and time
+    // text.TEXT("7/12/2022 10:38:00 am", "mm/dd/yyyy").should.equal("12/07/2022") // date
+    // text.TEXT("7/12/2022 10:38:00 am", "m/d/yyyy h:mm AM/PM").should.equal("12/7/2022 10:38 am") // date and time
+
+    // // fraction
+    // text.TEXT("4.34", "# ?/?").should.equal("4 1/3") // Up to one digit
+    // text.TEXT("0.34", "# ?/?").should.equal("1/3") // Up to one digit
+    // text.TEXT("4.34", "# ??/??").should.equal("4 17/50") // Up to two digits
+    // text.TEXT("4.34", "# ???/???").should.equal("4 169/500") // Up to three digits
+    // text.TEXT("4.34", "# ?/2").should.equal("4 1/2") // as halves
+    // text.TEXT("4.34", "# ?/4").should.equal("4 1/4") // as quarters
+    // text.TEXT("4.34", "# ?/16").should.equal("4 5/16") // as sixteenths
+    // text.TEXT("4.34", "# ?/10").should.equal("4 3/10") // as tenths
+    // text.TEXT("4.34", "# ?/100").should.equal("4 34/100") // as hundredths
+
+    // // scientific notation
+    // text.TEXT("12200000", "0.00E+00").should.equal("1.22E+07") // 7 places
+    // text.TEXT("12200000", "#0.0E+0").should.equal("12.2E+6") // 6 places
+
+    // special formats - e.g. zip code, zip +4, phone number, social security number
+    text.TEXT("12345", "00000").should.equal("12345")
+    text.TEXT("123456789", "00000-0000").should.equal("12345-6789")
+    // text.TEXT("1234567899", "[<=9999999]###-####;(###) ###-####").should.equal("(123) 456-7899")
+    text.TEXT("123456789", "000-00-0000").should.equal("123-45-6789")
+    // text.TEXT("123456", "000000000").should.equal("000123456")
+    // text.TEXT("123456", "###° 00' 00''").should.equal("12° 34' 56''")
+
+    // leading zeros
+    // text.TEXT("00001", "00000").should.equal("00001")
+    // text.TEXT("00012", "00000").should.equal("00012")
+    // text.TEXT("00123", "00000").should.equal("00123")
+    // text.TEXT("01234", "00000").should.equal("01234")
+    // text.TEXT("12345", "00000").should.equal("12345")
   })
 
   it('TEXTJOIN', () => {

--- a/test/text.js
+++ b/test/text.js
@@ -296,13 +296,15 @@ describe('Text', () => {
     text.T(true).should.equal('')
   })
 
-  it('TEXT', () => {
+  describe('TEXT', () => {
+    it('should return a error for invalid inputs', () => {
     text.TEXT().should.equal(error.na)
     text.TEXT('value').should.equal(error.na)
     text.TEXT("VALUE", "").should.equal(error.value)
     text.TEXT(12, "").should.equal("")
+    })
 
-    // percentage
+    it('should handle percentages correctly', () => {
     text.TEXT("0.244740088392962", "0%").should.equal("24%")
     text.TEXT("1.2555", "0%").should.equal("126%")
     text.TEXT("1.2555", "########.##########%").should.equal("125.55%")
@@ -317,108 +319,129 @@ describe('Text', () => {
     text.TEXT("0.244740088392962", "0 # %").should.equal("2 4 %")
     text.TEXT(1.244740088392962, "0 # %").should.equal("12 4 %")
     text.TEXT("1", "0 # %").should.equal("10 0 %")
+    })
 
-    // // thousands separator
-    // text.TEXT('122000000', '#,###').should.equal('122,000,000')
-    // text.TEXT('122000000', '0,000.00').should.equal('122,000,000.00')
-    // text.TEXT('122000000', '#,').should.equal('12200')
-    // text.TEXT('122000000', '#,###.0,').should.equal('12,200.0')
-    // text.TEXT('122000000', '0.0,,').should.equal('12.2')
-    // text.TEXT(1234.56, '#,##0').should.equal('1,235') // thousands separator, no decimals
-    // text.TEXT(1234.56, '#,##0.00').should.equal('1,234.56') // thousands separator, 2 decimals
+    xit('should handle thousands separator correctly', () => {
+      text.TEXT('122000000', '#,###').should.equal('122,000,000')
+      text.TEXT('122000000', '0,000.00').should.equal('122,000,000.00')
+      text.TEXT('122000000', '#,').should.equal('12200')
+      text.TEXT('122000000', '#,###.0,').should.equal('12,200.0')
+      text.TEXT('122000000', '0.0,,').should.equal('12.2')
+      text.TEXT(1234.56, '#,##0').should.equal('1,235') // thousands separator, no decimals
+      text.TEXT(1234.56, '#,##0.00').should.equal('1,234.56') // thousands separator, 2 decimals
+    })
 
-    // number
-    text.TEXT(1234.56, '0.00').should.equal('1234.56') // general
-    text.TEXT('1234.59', '###0.0').should.equal('1234.6')
-    text.TEXT('1234.52', '###0.0').should.equal('1234.5')
-    text.TEXT('1234.56', '###0.00').should.equal('1234.56')
+    it('should handle general numbers correctly', () => {
+      text.TEXT(1234.56, '0.00').should.equal('1234.56')
+      text.TEXT('1234.59', '###0.0').should.equal('1234.6')
+      text.TEXT('1234.52', '###0.0').should.equal('1234.5')
+      text.TEXT('1234.56', '###0.00').should.equal('1234.56')
+    })
 
-    // currency
-    text.TEXT(1234.56, '$###0').should.equal('$1235')
-    text.TEXT(1234.56, '$###0.00').should.equal('$1234.56')
-    // text.TEXT(1234.56, '$#,##0').should.equal('$1,235') // no decimals
-    // text.TEXT(1234.56, '$#,##0.00').should.equal('$1,234.56') // 2 decimals
-    // text.TEXT(-1234.56, '$#,##0.00_);($#,##0.00)').should.equal('-$1,234.56') // 2 decimals, negative value
-    // text.TEXT(2800, "$#,###").should.equal("$2,800")
+    it('should handle currency correctly', () => {
+      text.TEXT(1234.56, '$###0').should.equal('$1235')
+      text.TEXT(1234.56, '$###0.00').should.equal('$1234.56')
 
-    // // accounting
-    // text.TEXT(1234.56, '$ * #,##0').should.equal('$ 1,235') // no decimals
-    // text.TEXT(1234.56, '$ * #,##0.00').should.equal('$ 1,234.56') // 2 decimals
-    // text.TEXT(-1234.56, "_($* #,##0.00_);_($* (#,##0.00);_($* "-"??_);_(@_)").should.equal(error.value)
+      // text.TEXT(1234.56, '$#,##0').should.equal('$1,235') // no decimals
+      // text.TEXT(1234.56, '$#,##0.00').should.equal('$1,234.56') // 2 decimals
+      // text.TEXT(-1234.56, '$#,##0.00_);($#,##0.00)').should.equal('-$1,234.56') // 2 decimals, negative value
+      // text.TEXT(2800, "$#,###").should.equal("$2,800")
+    })
 
-    // // date - months
-    // text.TEXT("7/12/2022", "m").should.equal("12") // 1-12
-    // text.TEXT("7/12/2022", "mm").should.equal("12") // 01-12
-    // text.TEXT("7/12/2022", "mmm").should.equal("Dec") // Jan-Dec
-    // text.TEXT("7/12/2022", "mmmm").should.equal("December") // January-December
-    // text.TEXT("7/12/2022", "mmmmm").should.equal("D") // J-D
+    xit('should handle accounting correctly', () => {
+      text.TEXT(1234.56, '$ * #,##0').should.equal('$ 1,235') // no decimals
+      text.TEXT(1234.56, '$ * #,##0.00').should.equal('$ 1,234.56') // 2 decimals
+      text.TEXT(-1234.56, "_($* #,##0.00_);_($* (#,##0.00);_($* "-"??_);_(@_)").should.equal(error.value)
+    })
 
-    // // date - days
-    // text.TEXT("7/12/2022", "d").should.equal("7") // 1-31
-    // text.TEXT("7/12/2022", "dd").should.equal("07") // 01-31
-    // text.TEXT("7/12/2022", "ddd").should.equal("Wed") // Sun-Sat
-    // text.TEXT("7/12/2022", "dddd").should.equal("Wednesday") // Sunday-Saturday
+    xit('should handle a date (month) correctly', () => {
+      text.TEXT("7/12/2022", "m").should.equal("12") // 1-12
+      text.TEXT("7/12/2022", "mm").should.equal("12") // 01-12
+      text.TEXT("7/12/2022", "mmm").should.equal("Dec") // Jan-Dec
+      text.TEXT("7/12/2022", "mmmm").should.equal("December") // January-December
+      text.TEXT("7/12/2022", "mmmmm").should.equal("D") // J-D
+    })
 
-    // // date - years
-    // text.TEXT("7/12/2022", "yy").should.equal("22") // 00-99
-    // text.TEXT("7/12/2022", "yyyy").should.equal("2022") // 0000-9999
+    xit('should handle a date (day) correctly', () => {
+      text.TEXT("7/12/2022", "d").should.equal("7") // 1-31
+      text.TEXT("7/12/2022", "dd").should.equal("07") // 01-31
+      text.TEXT("7/12/2022", "ddd").should.equal("Wed") // Sun-Sat
+      text.TEXT("7/12/2022", "dddd").should.equal("Wednesday") // Sunday-Saturday
+    })
 
-    // // time - hours
-    // text.TEXT("10:38:00 am", "h").should.equal("10") // 0-23
-    // text.TEXT("10:38:00 am", "hh").should.equal("10") // 00-23
+    xit('should handle a date (year) correctly', () => {
+    text.TEXT("7/12/2022", "yy").should.equal("22") // 00-99
+    text.TEXT("7/12/2022", "yyyy").should.equal("2022") // 0000-9999
+    })
 
-    // // time - minutes
-    // text.TEXT("10:38:00 am", "m").should.equal("38") // 0-59
-    // text.TEXT("10:38:00 am", "mm").should.equal("38") // 00-59
+    // time - hours
+    xit('should handle a time (hour) correctly', () => {
+    text.TEXT("10:38:00 am", "h").should.equal("10") // 0-23
+    text.TEXT("10:38:00 am", "hh").should.equal("10") // 00-23
+    })
 
-    // // time - seconds
-    // text.TEXT("10:38:00 am", "s").should.equal("0") // 0-59
-    // text.TEXT("10:38:00 am", "ss").should.equal("00") // 00-59
+    xit('should handle a time (minute) correctly', () => {
+    text.TEXT("10:38:00 am", "m").should.equal("38") // 0-59
+    text.TEXT("10:38:00 am", "mm").should.equal("38") // 00-59
+    })
 
-    // // time - am/pm
-    // text.TEXT("10:38:00 am", "h AM/PM").should.equal("10 am")
-    // text.TEXT("10:38:00 am", "h:mm AM/PM").should.equal("10:38 am")
-    // text.TEXT("10:38:00 am", "h:mm:ss A/P").should.equal("10:38:00 A/P")
-    // text.TEXT("10:38:00 am", "h:mm:ss.00").should.equal("10:38:00.00")
+    xit('should handle a time (second) correctly', () => {
+    text.TEXT("10:38:00 am", "s").should.equal("0") // 0-59
+    text.TEXT("10:38:00 am", "ss").should.equal("00") // 00-59
+    })
 
-    // // time - elapsed time
-    // text.TEXT("1:02:16 am", "[h]:mm").should.equal("1:02") // hours and minutes
-    // text.TEXT("1:02:16 am", "[mm]:ss").should.equal("62:16") // minutes and seconds
-    // text.TEXT("1:02:16 am", "[ss].00").should.equal("3736.00") // seconds and hundredths
+    xit('should handle a time (am/pm) correctly', () => {
+    text.TEXT("10:38:00 am", "h AM/PM").should.equal("10 am")
+    text.TEXT("10:38:00 am", "h:mm AM/PM").should.equal("10:38 am")
+    text.TEXT("10:38:00 am", "h:mm:ss A/P").should.equal("10:38:00 A/P")
+    text.TEXT("10:38:00 am", "h:mm:ss.00").should.equal("10:38:00.00")
+    })
 
-    // // date and time
-    // text.TEXT("7/12/2022 10:38:00 am", "mm/dd/yyyy").should.equal("12/07/2022") // date
-    // text.TEXT("7/12/2022 10:38:00 am", "m/d/yyyy h:mm AM/PM").should.equal("12/7/2022 10:38 am") // date and time
+    xit('should handle elapsed time correctly', () => {
+    text.TEXT("1:02:16 am", "[h]:mm").should.equal("1:02") // hours and minutes
+    text.TEXT("1:02:16 am", "[mm]:ss").should.equal("62:16") // minutes and seconds
+    text.TEXT("1:02:16 am", "[ss].00").should.equal("3736.00") // seconds and hundredths
+    })
 
-    // // fraction
-    // text.TEXT("4.34", "# ?/?").should.equal("4 1/3") // Up to one digit
-    // text.TEXT("0.34", "# ?/?").should.equal("1/3") // Up to one digit
-    // text.TEXT("4.34", "# ??/??").should.equal("4 17/50") // Up to two digits
-    // text.TEXT("4.34", "# ???/???").should.equal("4 169/500") // Up to three digits
-    // text.TEXT("4.34", "# ?/2").should.equal("4 1/2") // as halves
-    // text.TEXT("4.34", "# ?/4").should.equal("4 1/4") // as quarters
-    // text.TEXT("4.34", "# ?/16").should.equal("4 5/16") // as sixteenths
-    // text.TEXT("4.34", "# ?/10").should.equal("4 3/10") // as tenths
-    // text.TEXT("4.34", "# ?/100").should.equal("4 34/100") // as hundredths
+    xit('should handle a date and time correctly', () => {
+    text.TEXT("7/12/2022 10:38:00 am", "mm/dd/yyyy").should.equal("12/07/2022") // date
+    text.TEXT("7/12/2022 10:38:00 am", "m/d/yyyy h:mm AM/PM").should.equal("12/7/2022 10:38 am") // date and time
+    })
 
-    // // scientific notation
-    // text.TEXT("12200000", "0.00E+00").should.equal("1.22E+07") // 7 places
-    // text.TEXT("12200000", "#0.0E+0").should.equal("12.2E+6") // 6 places
+    xit('should handle a fraction correctly', () => {
+    text.TEXT("4.34", "# ?/?").should.equal("4 1/3") // Up to one digit
+    text.TEXT("0.34", "# ?/?").should.equal("1/3") // Up to one digit
+    text.TEXT("4.34", "# ??/??").should.equal("4 17/50") // Up to two digits
+    text.TEXT("4.34", "# ???/???").should.equal("4 169/500") // Up to three digits
+    text.TEXT("4.34", "# ?/2").should.equal("4 1/2") // as halves
+    text.TEXT("4.34", "# ?/4").should.equal("4 1/4") // as quarters
+    text.TEXT("4.34", "# ?/16").should.equal("4 5/16") // as sixteenths
+    text.TEXT("4.34", "# ?/10").should.equal("4 3/10") // as tenths
+    text.TEXT("4.34", "# ?/100").should.equal("4 34/100") // as hundredths
+    })
 
-    // special formats - e.g. zip code, zip +4, phone number, social security number
-    text.TEXT("12345", "00000").should.equal("12345")
-    text.TEXT("123456789", "00000-0000").should.equal("12345-6789")
-    // text.TEXT("1234567899", "[<=9999999]###-####;(###) ###-####").should.equal("(123) 456-7899")
-    text.TEXT("123456789", "000-00-0000").should.equal("123-45-6789")
-    // text.TEXT("123456", "000000000").should.equal("000123456")
-    // text.TEXT("123456", "###° 00' 00''").should.equal("12° 34' 56''")
+    xit('should handle scientific notation correctly', () => {
+    text.TEXT("12200000", "0.00E+00").should.equal("1.22E+07") // 7 places
+    text.TEXT("12200000", "#0.0E+0").should.equal("12.2E+6") // 6 places
+    })
 
-    // leading zeros
-    // text.TEXT("00001", "00000").should.equal("00001")
-    // text.TEXT("00012", "00000").should.equal("00012")
-    // text.TEXT("00123", "00000").should.equal("00123")
-    // text.TEXT("01234", "00000").should.equal("01234")
-    // text.TEXT("12345", "00000").should.equal("12345")
+    it("should format special formats, e.g. zip code, zip +4, phone number, social security number", () => {
+      text.TEXT("12345", "00000").should.equal("12345")
+      text.TEXT("123456789", "00000-0000").should.equal("12345-6789")
+      text.TEXT("123456789", "000-00-0000").should.equal("123-45-6789")
+
+      // text.TEXT("123456", "000000000").should.equal("000123456")
+      // text.TEXT("123456", "###° 00' 00''").should.equal("12° 34' 56''")
+      // text.TEXT("1234567899", "[<=9999999]###-####;(###) ###-####").should.equal("(123) 456-7899")
+    })
+
+    xit("should format leading zeros", () => {
+      text.TEXT("00001", "00000").should.equal("00001")
+      text.TEXT("00012", "00000").should.equal("00012")
+      text.TEXT("00123", "00000").should.equal("00123")
+      text.TEXT("01234", "00000").should.equal("01234")
+      text.TEXT("12345", "00000").should.equal("12345")
+    })
   })
 
   it('TEXTJOIN', () => {

--- a/test/text.js
+++ b/test/text.js
@@ -296,7 +296,7 @@ describe('Text', () => {
     text.T(true).should.equal('')
   })
 
-  it.only('TEXT', () => {
+  it('TEXT', () => {
     text.TEXT().should.equal(error.na)
     text.TEXT('value').should.equal(error.na)
     text.TEXT("VALUE", "").should.equal(error.value)


### PR DESCRIPTION
Partially implemented for decimals, percentages, general numbers, some currency formats, plus maybe a few more.

The following are not supported:
 - Scientific notation
 - Leading and trailing zeros
 - Some special formats like "[<=9999999]###-####;(###) ###-####", "###° 00' 00''"
 - Fractions
 - Dates and times
 - Some accounting formats
 - Thousands separator

I did created associated test cases for the above though. Right now, they are just commented out. Should be easy to pick up later on.

Linked issue is here: https://github.com/formulajs/formulajs/issues/117

Excel reference: https://support.microsoft.com/en-us/office/text-function-20d5ac4d-7b94-49fd-bb38-93d29371225c

Sample Excel sheet of some test cases:
[TEXT function examples.xlsx](https://github.com/formulajs/formulajs/files/10182081/TEXT.function.examples.xlsx)
