### PR TITLE
Fix WORKDAY.INTL  Allow negative number in days parameter (#153)

### DIFF
--- a/src/date-time.js
+++ b/src/date-time.js
@@ -718,10 +718,6 @@ WORKDAY.INTL = (start_date, days, weekend, holidays) => {
     return days
   }
 
-  if (days < 0) {
-    return error.num
-  }
-
   if (weekend === undefined) {
     weekend = WEEKEND_TYPES[1]
   } else {
@@ -748,30 +744,44 @@ WORKDAY.INTL = (start_date, days, weekend, holidays) => {
     holidays[i] = h
   }
 
-  let d = 0
+  if (days !== 0) {
+    let d = 0
+    let diff = 1
 
-  while (d < days) {
-    start_date.setDate(start_date.getDate() + 1)
-    const day = start_date.getDay()
-
-    if (day === weekend[0] || day === weekend[1]) {
-      continue
+    if (days > 0) {
+      diff = 1
+    } else {
+      diff = -1
+      days *= -1
     }
 
-    for (let j = 0; j < holidays.length; j++) {
-      const holiday = holidays[j]
+    while (d < days) {
+      start_date.setDate(start_date.getDate() + diff)
+      const day = start_date.getDay()
 
-      if (
-        holiday.getDate() === start_date.getDate() &&
-        holiday.getMonth() === start_date.getMonth() &&
-        holiday.getFullYear() === start_date.getFullYear()
-      ) {
-        d--
-        break
+      if (day === weekend[0] || day === weekend[1]) {
+        continue
       }
-    }
 
-    d++
+      for (let j = 0; j < holidays.length; j++) {
+        const holiday = holidays[j]
+
+        if (
+          holiday.getDate() === start_date.getDate() &&
+          holiday.getMonth() === start_date.getMonth() &&
+          holiday.getFullYear() === start_date.getFullYear()
+        ) {
+          d--
+          break
+        }
+      }
+
+      d++
+    }
+  }
+  // EXCEL does not recognize dates before 1900.
+  if (start_date.getFullYear() < 1900) {
+    return error.date
   }
 
   return start_date

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -218,13 +218,17 @@ describe('Date & Time', () => {
   })
 
   it('WORKDAY', () => {
+    expect(dateTime.WORKDAY('2023-05-05', -10, ['2023-04-29', '2023-04-30', '2023-05-01']).getDate()).to.equal(20)
     expect(dateTime.WORKDAY('1/1/1900', 1).getDate()).to.equal(2)
     expect(dateTime.WORKDAY('1/1/1900', 7).getDate()).to.equal(10)
+    expect(dateTime.WORKDAY('2/28/1900', -1).getDate()).to.equal(27)
+    expect(dateTime.WORKDAY('1/18/1900', -7).getDate()).to.equal(9)
+    expect(dateTime.WORKDAY('3/5/1900', -1, '3/2/1900').getDate()).to.equal(1)
     expect(dateTime.WORKDAY('1/1/1900', 2, '1/2/1900').getDate()).to.equal(4)
     expect(dateTime.WORKDAY('a', 1, '1/2/1900')).to.equal(error.value)
     expect(dateTime.WORKDAY('1/1/1900', 'a')).to.equal(error.value)
     expect(dateTime.WORKDAY('1/1/1900', 1, 'a')).to.equal(error.value)
-    expect(dateTime.WORKDAY('1/1/1900', -1)).to.equal(error.num)
+    expect(dateTime.WORKDAY('1/1/1900', -1)).to.equal(error.date)
   })
 
   it('WORKDAY.INTL', () => {


### PR DESCRIPTION
Fix this bug, WORKDAY.INTL  allow negative number in days parameter, and execl does not support dates before 1900，return `error.date`