### PR TITLE
Bug GROWTH for one row notation

### DIFF
--- a/src/statistical.js
+++ b/src/statistical.js
@@ -1310,7 +1310,7 @@ export function GEOMEAN() {
  */
 export function GROWTH(known_y, known_x, new_x, use_const) {
   // Credits: Ilmari Karonen (http://stackoverflow.com/questions/14161990/how-to-implement-growth-function-in-javascript)
-  known_y = utils.parseNumberArray(known_y)
+  known_y = utils.parseNumberArray(utils.flatten(known_y))
 
   if (known_y instanceof Error) {
     return known_y
@@ -1335,7 +1335,7 @@ export function GROWTH(known_y, known_x, new_x, use_const) {
     }
   }
 
-  known_x = utils.parseNumberArray(known_x)
+  known_x = utils.parseNumberArray(utils.flatten(known_x))
   new_x = utils.parseNumberArray(utils.flatten(new_x))
 
   if (utils.anyIsError(known_x, new_x)) {

--- a/test/statistical.js
+++ b/test/statistical.js
@@ -499,6 +499,20 @@ describe('Statistical', () => {
       )
     })
 
+    it('should work with array-like row notation', () => {
+      const one_row_known_y = [known_y]
+      const one_row_known_x = [known_x]
+      const one_row_new_x = [new_x]
+
+      expect(mathTrig.SUM(statistical.GROWTH(one_row_known_y, one_row_known_x, one_row_new_x))).to.approximately(
+        mathTrig.SUM([
+          32618.203773538437, 47729.42261474665, 69841.30085621694, 102197.07337883314, 149542.4867400494,
+          218821.87621460424, 320196.7183634903, 468536.05418408214, 685597.3889812973
+        ]),
+        1e-6
+      )
+    })
+
     it('should accept non-array value for new_x', () => {
       expect(mathTrig.SUM(statistical.GROWTH(known_y, known_x, [11]))).to.approximately(
         mathTrig.SUM([32618.203773538437]),


### PR DESCRIPTION
Following #167, another edge-case with single row notation:

```
[
 [ 1, 2, 3]
]
```