### PR TITLE
bug MATCH lookup_value of 0 throws n/a

### DIFF
--- a/src/lookup-reference.js
+++ b/src/lookup-reference.js
@@ -193,7 +193,7 @@ export function LOOKUP(lookup_value, array, result_array) {
  * @returns
  */
 export function MATCH(lookup_value, lookup_array, match_type) {
-  if (!lookup_value || !lookup_array) {
+  if ((!lookup_value && lookup_value !== 0) || !lookup_array) {
     return error.na
   }
 

--- a/test/lookup-reference.js
+++ b/test/lookup-reference.js
@@ -79,6 +79,7 @@ describe('Lookup Reference', () => {
     })
 
     it('should return the following values', () => {
+      expect(lookup.MATCH(0, [7, 1, 0, 3, 4, 100, 7], 0)).to.equal(3)
       expect(lookup.MATCH(1, [0, 1, 2, 3, 4, 100, 7])).to.equal(2)
       expect(lookup.MATCH(1, [[0], [1], [2], [3], [4]])).to.equal(2)
       expect(lookup.MATCH(4, [0, 1, 2, 3, 4, 100, 7], 1)).to.equal(5)


### PR DESCRIPTION
Fixes MATCH if you pass 0 instance in to lookup_value