### PR TITLE
Fix TEXT

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -1,6 +1,6 @@
 import * as error from './utils/error.js'
 import * as utils from './utils/common.js'
-import {ROUND} from './math-trig.js'
+import { ROUND } from './math-trig.js'
 
 // TODO
 /**

--- a/src/text.js
+++ b/src/text.js
@@ -1,6 +1,6 @@
 import * as error from './utils/error.js'
 import * as utils from './utils/common.js'
-import { ROUND } from './math-trig.js'
+import {ROUND} from './math-trig.js'
 
 // TODO
 /**
@@ -600,6 +600,10 @@ export function TEXT(value, format_text) {
     return error.na
   }
 
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10)
+  }
+
   if (format_text === undefined || format_text === null) {
     return ''
   }
@@ -617,7 +621,7 @@ export function TEXT(value, format_text) {
   format_text = format_text.replace(/%/g, '').replace(/\$/g, '')
 
   // count all 0s after the decimal point
-  const decimalPlaces = format_text.split('.')[1].match(/0/g).length
+  const decimalPlaces = format_text.includes('.') ? format_text.split('.')[1].match(/0/g).length : 0
 
   const noCommas = !format_text.includes(',')
 

--- a/test/text.js
+++ b/test/text.js
@@ -1,4 +1,4 @@
-import {expect} from 'chai'
+import { expect } from 'chai'
 
 import * as error from '../src/utils/error.js'
 import * as text from '../src/text.js'
@@ -323,8 +323,7 @@ describe('Text', () => {
 
     describe('does not support date formatting but should not crash', () => {
       it('should return ISO formatted Date', () => {
-        expect(text.TEXT(new Date(2023, 3, 11, 12), "DD MMMM, YYYY"))
-          .to.equal('2023-04-11')
+        expect(text.TEXT(new Date(2023, 3, 11, 12), 'DD MMMM, YYYY')).to.equal('2023-04-11')
       })
     })
   })

--- a/test/text.js
+++ b/test/text.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import {expect} from 'chai'
 
 import * as error from '../src/utils/error.js'
 import * as text from '../src/text.js'
@@ -289,6 +289,7 @@ describe('Text', () => {
   describe('TEXT', () => {
     it('should use fixed number of decimals and include commas if specified', () => {
       expect(text.TEXT(1234.59, '###0.0')).to.equal('1234.6')
+      expect(text.TEXT(1234.59, '0')).to.equal('1235')
       expect(text.TEXT(1234.52, '###0.0')).to.equal('1234.5')
       expect(text.TEXT(1234.56, '###0.00')).to.equal('1234.56')
       expect(text.TEXT(1234, '###0.0000')).to.equal('1234.0000')
@@ -318,6 +319,13 @@ describe('Text', () => {
       expect(text.TEXT(123, null)).to.equal('')
       expect(text.TEXT(123, 111)).to.equal('111')
       expect(text.TEXT(123, true)).to.equal(error.value)
+    })
+
+    describe('does not support date formatting but should not crash', () => {
+      it('should return ISO formatted Date', () => {
+        expect(text.TEXT(new Date(2023, 3, 11, 12), "DD MMMM, YYYY"))
+          .to.equal('2023-04-11')
+      })
     })
   })
 


### PR DESCRIPTION
Two new cases:

1) Date input => not supported but avoid throwing an error by returning ISO formatted date.

2) Number inputs and format without decimal position