### PR TITLE
Add the ability to return Serial instead of plain JS Date

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default [
       ecmaVersion: 'latest',
       globals: {
         describe: 'readonly',
+        beforeEach: 'readonly',
         it: 'readonly',
         should: 'readonly',
         xit: 'readonly',

--- a/src/date-time.js
+++ b/src/date-time.js
@@ -1,7 +1,7 @@
 import * as error from './utils/error.js'
 import * as utils from './utils/common.js'
+import {dateToSerial, returnSerial} from "./utils/date.js";
 
-const d1900 = new Date(Date.UTC(1900, 0, 1))
 const WEEK_STARTS = [
   undefined,
   0,
@@ -91,7 +91,7 @@ export function DATE(year, month, day) {
     }
   }
 
-  return result
+  return returnSerial ? dateToSerial(result) : result
 }
 
 /**
@@ -197,7 +197,9 @@ export function DATEVALUE(date_text) {
     return error.value
   }
 
-  return new Date(date_text)
+  const dateValue = new Date(date_text);
+
+  return returnSerial ? dateToSerial(dateValue) : dateValue;
 }
 
 /**
@@ -246,7 +248,7 @@ export function DAYS(end_date, start_date) {
     return start_date
   }
 
-  return serial(startOfDay(end_date)) - serial(startOfDay(start_date))
+  return dateToSerial(startOfDay(end_date)) - dateToSerial(startOfDay(start_date))
 }
 
 /**
@@ -346,7 +348,7 @@ export function EDATE(start_date, months) {
 
   start_date.setDate(storedDay)
 
-  return start_date
+  return returnSerial ? dateToSerial(start_date) : start_date
 }
 
 /**
@@ -371,7 +373,9 @@ export function EOMONTH(start_date, months) {
 
   months = parseInt(months, 10)
 
-  return new Date(start_date.getFullYear(), start_date.getMonth() + months + 1, 0)
+  const eoMonth = new Date(start_date.getFullYear(), start_date.getMonth() + months + 1, 0)
+
+  return returnSerial ? dateToSerial(eoMonth) : eoMonth
 }
 
 /**
@@ -567,7 +571,7 @@ NETWORKDAYS.INTL = (start_date, end_date, weekend, holidays) => {
  * @returns
  */
 export function NOW() {
-  return new Date()
+  return returnSerial ? dateToSerial(new Date()) : new Date()
 }
 
 /**
@@ -640,7 +644,8 @@ export function TIMEVALUE(time_text) {
  * @returns
  */
 export function TODAY() {
-  return startOfDay(new Date())
+  const today = startOfDay(new Date());
+  return returnSerial ? dateToSerial(today) : today;
 }
 
 /**
@@ -918,10 +923,4 @@ export function YEARFRAC(start_date, end_date, basis) {
 
       return (ed + em * 30 + ey * 360 - (sd + sm * 30 + sy * 360)) / 360
   }
-}
-
-function serial(date) {
-  const addOn = date > -2203891200000 ? 2 : 1
-
-  return Math.ceil((date - d1900) / 86400000) + addOn
 }

--- a/src/date-time.js
+++ b/src/date-time.js
@@ -1,6 +1,6 @@
 import * as error from './utils/error.js'
 import * as utils from './utils/common.js'
-import {dateToSerial, returnSerial} from "./utils/date.js";
+import { dateToSerial, returnSerial } from './utils/date.js'
 
 const WEEK_STARTS = [
   undefined,
@@ -197,9 +197,9 @@ export function DATEVALUE(date_text) {
     return error.value
   }
 
-  const dateValue = new Date(date_text);
+  const dateValue = new Date(date_text)
 
-  return returnSerial ? dateToSerial(dateValue) : dateValue;
+  return returnSerial ? dateToSerial(dateValue) : dateValue
 }
 
 /**
@@ -644,8 +644,8 @@ export function TIMEVALUE(time_text) {
  * @returns
  */
 export function TODAY() {
-  const today = startOfDay(new Date());
-  return returnSerial ? dateToSerial(today) : today;
+  const today = startOfDay(new Date())
+  return returnSerial ? dateToSerial(today) : today
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import * as errors from './utils/error.js'
+import * as date from './utils/date.js'
 import * as symbols from './utils/symbol.js'
 
 export * from './compatibility.js'
@@ -13,4 +14,4 @@ export * from './math-trig.js'
 export * from './statistical.js'
 export * from './text.js'
 
-export const utils = { errors, symbols }
+export const utils = { errors, symbols, date }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,6 +1,6 @@
 import * as error from './error.js'
 import * as evalExpression from './criteria-eval.js'
-import {serialToDate} from "./date.js";
+import { serialToDate } from './date.js'
 
 // Arrays
 export function argsToArray(args) {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,5 +1,6 @@
 import * as error from './error.js'
 import * as evalExpression from './criteria-eval.js'
+import {serialToDate} from "./date.js";
 
 // Arrays
 export function argsToArray(args) {
@@ -225,35 +226,6 @@ export function numbers() {
   return possibleNumbers.filter((el) => typeof el === 'number')
 }
 
-export function serialNumberToDate(serial) {
-  if (serial < 60) {
-    serial += 1
-  }
-
-  const utc_days = Math.floor(serial - 25569)
-  const utc_value = utc_days * 86400
-  const date_info = new Date(utc_value * 1000)
-  const fractional_day = serial - Math.floor(serial) + 0.0000001
-
-  let total_seconds = Math.floor(86400 * fractional_day)
-
-  const seconds = total_seconds % 60
-
-  total_seconds -= seconds
-
-  const hours = Math.floor(total_seconds / (60 * 60))
-  const minutes = Math.floor(total_seconds / 60) % 60
-  let days = date_info.getUTCDate()
-  let month = date_info.getUTCMonth()
-
-  if (serial >= 60 && serial < 61) {
-    days = 29
-    month = 1
-  }
-
-  return new Date(date_info.getUTCFullYear(), month, days, hours, minutes, seconds)
-}
-
 // Parsers
 export function parseBool(bool) {
   if (typeof bool === 'boolean') {
@@ -299,7 +271,7 @@ export function parseDate(date) {
       return error.num
     }
 
-    return serialNumberToDate(d)
+    return serialToDate(d)
   }
 
   if (typeof date === 'string') {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,47 @@
+export let returnSerial = false;
+
+const d1900 = new Date(Date.UTC(1900, 0, 1))
+
+export function useSerial() {
+  returnSerial = true;
+}
+
+export function useDate() {
+  returnSerial = false;
+}
+
+export function serialToDate(serial) {
+  if (serial < 60) {
+    serial += 1
+  }
+
+  const utc_days = Math.floor(serial - 25569)
+  const utc_value = utc_days * 86400
+  const date_info = new Date(utc_value * 1000)
+  const fractional_day = serial - Math.floor(serial) + 0.0000001
+
+  let total_seconds = Math.floor(86400 * fractional_day)
+
+  const seconds = total_seconds % 60
+
+  total_seconds -= seconds
+
+  const hours = Math.floor(total_seconds / (60 * 60))
+  const minutes = Math.floor(total_seconds / 60) % 60
+  let days = date_info.getUTCDate()
+  let month = date_info.getUTCMonth()
+
+  if (serial >= 60 && serial < 61) {
+    days = 29
+    month = 1
+  }
+
+  return new Date(date_info.getUTCFullYear(), month, days, hours, minutes, seconds)
+}
+
+
+export function dateToSerial(date) {
+  const addOn = date > -2203891200000 ? 2 : 1
+
+  return Math.ceil((date - d1900) / 86400000) + addOn
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,13 +1,13 @@
-export let returnSerial = false;
+export let returnSerial = false
 
 const d1900 = new Date(Date.UTC(1900, 0, 1))
 
 export function useSerial() {
-  returnSerial = true;
+  returnSerial = true
 }
 
 export function useDate() {
-  returnSerial = false;
+  returnSerial = false
 }
 
 export function serialToDate(serial) {
@@ -38,7 +38,6 @@ export function serialToDate(serial) {
 
   return new Date(date_info.getUTCFullYear(), month, days, hours, minutes, seconds)
 }
-
 
 export function dateToSerial(date) {
   const addOn = date > -2203891200000 ? 2 : 1

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -37,6 +37,11 @@ describe('Date & Time', () => {
       expect(date.getDate()).to.equal(1)
     })
 
+    it('should return a Serial number', () => {
+      useSerial()
+      expect(dateTime.DATE(2008, 2, 29)).to.equal(39507)
+    })
+
     xit('should be Excel behaviour, but we do not want to recreate it', () => {
       expect(dateTime.DATE(1899, 1, 1).getFullYear()).to.equal(3799)
     })
@@ -64,11 +69,18 @@ describe('Date & Time', () => {
     expect(dateTime.DATEDIF('1959-07-20', '2020-05-04', 'md')).to.equal(14)
   })
 
-  it('DATEVALUE', () => {
-    expect(dateTime.DATEVALUE('1/1/1900')).to.deep.equal(new Date(1900, 0, 1))
-    expect(dateTime.DATEVALUE('12/31/9999')).to.deep.equal(new Date(9999, 11, 31))
-    expect(dateTime.DATEVALUE('foo bar')).to.equal(error.value)
-    expect(dateTime.DATEVALUE(1)).to.equal(error.value)
+  describe('DATEVALUE', () => {
+    it('should parse a date string', () => {
+      expect(dateTime.DATEVALUE('1/1/1900')).to.deep.equal(new Date(1900, 0, 1))
+      expect(dateTime.DATEVALUE('12/31/9999')).to.deep.equal(new Date(9999, 11, 31))
+      expect(dateTime.DATEVALUE('foo bar')).to.equal(error.value)
+      expect(dateTime.DATEVALUE(1)).to.equal(error.value)
+    })
+
+    it('should return a Serial number', () => {
+      useSerial()
+      expect(dateTime.DATEVALUE('02/29/2008')).to.equal(39507)
+    })
   })
 
   it('DAY', () => {
@@ -108,8 +120,8 @@ describe('Date & Time', () => {
     expect(dateTime.DAYS360('1/1/1901', '1/2/1901', 'a')).to.equal(error.value)
   })
 
-  describe('', () => {
-    it('EDATE', () => {
+  describe('EDATE', () => {
+    it('should compute EDATE', () => {
       expect(dateTime.EDATE('a', 0)).to.equal(error.value)
       expect(dateTime.EDATE('1/1/1900', 'a')).to.equal(error.value)
       expect(dateTime.EDATE(new Date(2011, 0, 23), 1)).to.deep.equal(new Date(2011, 1, 23))

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -1,9 +1,14 @@
-import { expect } from 'chai'
+import {expect} from 'chai'
 
 import * as dateTime from '../src/date-time.js'
 import * as error from '../src/utils/error.js'
+import {useDate, useSerial} from "../src/utils/date.js";
 
 describe('Date & Time', () => {
+  beforeEach(() => {
+    useDate();
+  })
+
   describe('DATE', () => {
     it('should thrown an error in case of malformed input', () => {
       expect(dateTime.DATE(10, 1, 1).getFullYear()).to.equal(1910)
@@ -103,29 +108,43 @@ describe('Date & Time', () => {
     expect(dateTime.DAYS360('1/1/1901', '1/2/1901', 'a')).to.equal(error.value)
   })
 
-  it('EDATE', () => {
-    expect(dateTime.EDATE('a', 0)).to.equal(error.value)
-    expect(dateTime.EDATE('1/1/1900', 'a')).to.equal(error.value)
-    expect(dateTime.EDATE(new Date(2011, 0, 23), 1)).to.deep.equal(new Date(2011, 1, 23))
-    expect(dateTime.EDATE(new Date(2023, 2, 27), 1)).to.deep.equal(new Date(2023, 3, 27))
-    expect(dateTime.EDATE(new Date(2023, 2, 28), 1)).to.deep.equal(new Date(2023, 3, 28))
-    expect(dateTime.EDATE(new Date(2023, 2, 29), 1)).to.deep.equal(new Date(2023, 3, 29))
-    expect(dateTime.EDATE(new Date(2023, 2, 30), 1)).to.deep.equal(new Date(2023, 3, 30))
-    expect(dateTime.EDATE(new Date(2023, 2, 31), 1)).to.deep.equal(new Date(2023, 3, 30))
-    expect(dateTime.EDATE(new Date(2023, 2, 27), -1)).to.deep.equal(new Date(2023, 1, 27))
-    expect(dateTime.EDATE(new Date(2023, 2, 28), -1)).to.deep.equal(new Date(2023, 1, 28))
-    expect(dateTime.EDATE(new Date(2023, 2, 29), -1)).to.deep.equal(new Date(2023, 1, 28))
-    expect(dateTime.EDATE(new Date(2023, 2, 30), -1)).to.deep.equal(new Date(2023, 1, 28))
-    expect(dateTime.EDATE(new Date(2023, 2, 31), -1)).to.deep.equal(new Date(2023, 1, 28))
-    expect(dateTime.EDATE(new Date(2008, 2, 31), -1)).to.deep.equal(new Date(2008, 1, 29))
-    expect(dateTime.EDATE(new Date(2100, 2, 31), -1)).to.deep.equal(new Date(2100, 1, 28))
+  describe('', () => {
+    it('EDATE', () => {
+      expect(dateTime.EDATE('a', 0)).to.equal(error.value)
+      expect(dateTime.EDATE('1/1/1900', 'a')).to.equal(error.value)
+      expect(dateTime.EDATE(new Date(2011, 0, 23), 1)).to.deep.equal(new Date(2011, 1, 23))
+      expect(dateTime.EDATE(new Date(2023, 2, 27), 1)).to.deep.equal(new Date(2023, 3, 27))
+      expect(dateTime.EDATE(new Date(2023, 2, 28), 1)).to.deep.equal(new Date(2023, 3, 28))
+      expect(dateTime.EDATE(new Date(2023, 2, 29), 1)).to.deep.equal(new Date(2023, 3, 29))
+      expect(dateTime.EDATE(new Date(2023, 2, 30), 1)).to.deep.equal(new Date(2023, 3, 30))
+      expect(dateTime.EDATE(new Date(2023, 2, 31), 1)).to.deep.equal(new Date(2023, 3, 30))
+      expect(dateTime.EDATE(new Date(2023, 2, 27), -1)).to.deep.equal(new Date(2023, 1, 27))
+      expect(dateTime.EDATE(new Date(2023, 2, 28), -1)).to.deep.equal(new Date(2023, 1, 28))
+      expect(dateTime.EDATE(new Date(2023, 2, 29), -1)).to.deep.equal(new Date(2023, 1, 28))
+      expect(dateTime.EDATE(new Date(2023, 2, 30), -1)).to.deep.equal(new Date(2023, 1, 28))
+      expect(dateTime.EDATE(new Date(2023, 2, 31), -1)).to.deep.equal(new Date(2023, 1, 28))
+      expect(dateTime.EDATE(new Date(2008, 2, 31), -1)).to.deep.equal(new Date(2008, 1, 29))
+      expect(dateTime.EDATE(new Date(2100, 2, 31), -1)).to.deep.equal(new Date(2100, 1, 28))
+    })
+
+    it('should return Serial', () => {
+      useSerial()
+      expect(dateTime.EDATE(new Date(2008, 2, 31), -1)).to.equal(39507)
+    })
   })
 
-  it('EOMONTH', () => {
-    expect(dateTime.EOMONTH('a', 0)).to.equal(error.value)
-    expect(dateTime.EOMONTH('1/1/1900', 'a')).to.equal(error.value)
-    expect(dateTime.EOMONTH('1/1/2005', 12)).to.deep.equal(new Date(2006, 0, 31))
-    expect(dateTime.EOMONTH(new Date(2011, 0, 2), 1)).to.deep.equal(new Date(2011, 1, 28))
+  describe('EOMONTH', () => {
+    it('EOMONTH', () => {
+      expect(dateTime.EOMONTH('a', 0)).to.equal(error.value)
+      expect(dateTime.EOMONTH('1/1/1900', 'a')).to.equal(error.value)
+      expect(dateTime.EOMONTH('1/1/2005', 12)).to.deep.equal(new Date(2006, 0, 31))
+      expect(dateTime.EOMONTH(new Date(2011, 0, 2), 1)).to.deep.equal(new Date(2011, 1, 28))
+    })
+
+    it('should return Serial', () => {
+      useSerial()
+      expect(dateTime.EOMONTH('1/1/2005', 12)).to.equal(38748)
+    })
   })
 
   it('HOUR', () => {
@@ -185,8 +204,15 @@ describe('Date & Time', () => {
     expect(dateTime.NETWORKDAYS.INTL('11/01/2021', '11/30/2021', '1110111')).to.equal(4)
   })
 
-  it('NOW', () => {
-    expect(dateTime.NOW()).to.instanceof(Date)
+  describe('NOW', () => {
+    it('NOW', () => {
+      expect(dateTime.NOW()).to.instanceof(Date)
+    })
+
+    it('should be able to return Serial', () => {
+      useSerial()
+      expect(dateTime.NOW()).to.be.a('number')
+    })
   })
 
   it('SECOND', () => {
@@ -208,11 +234,18 @@ describe('Date & Time', () => {
     expect(dateTime.TIMEVALUE('a')).to.equal(error.value)
   })
 
-  it('TODAY', () => {
-    expect(dateTime.TODAY()).to.instanceof(Date)
-    expect(dateTime.TODAY().getHours()).to.equal(0)
-    expect(dateTime.TODAY().getMinutes()).to.equal(0)
-    expect(dateTime.TODAY().getSeconds()).to.equal(0)
+  describe('TODAY', () => {
+    it('should return today\'s date at the start of the day', () => {
+      expect(dateTime.TODAY()).to.instanceof(Date)
+      expect(dateTime.TODAY().getHours()).to.equal(0)
+      expect(dateTime.TODAY().getMinutes()).to.equal(0)
+      expect(dateTime.TODAY().getSeconds()).to.equal(0)
+    })
+
+    it('should return Serial', () => {
+      useSerial();
+      expect(dateTime.TODAY()).to.be.a('number')
+    })
   })
 
   it('WEEKDAY', () => {

--- a/test/date-time.js
+++ b/test/date-time.js
@@ -1,12 +1,12 @@
-import {expect} from 'chai'
+import { expect } from 'chai'
 
 import * as dateTime from '../src/date-time.js'
 import * as error from '../src/utils/error.js'
-import {useDate, useSerial} from "../src/utils/date.js";
+import { useDate, useSerial } from '../src/utils/date.js'
 
 describe('Date & Time', () => {
   beforeEach(() => {
-    useDate();
+    useDate()
   })
 
   describe('DATE', () => {
@@ -235,7 +235,7 @@ describe('Date & Time', () => {
   })
 
   describe('TODAY', () => {
-    it('should return today\'s date at the start of the day', () => {
+    it("should return today's date at the start of the day", () => {
       expect(dateTime.TODAY()).to.instanceof(Date)
       expect(dateTime.TODAY().getHours()).to.equal(0)
       expect(dateTime.TODAY().getMinutes()).to.equal(0)
@@ -243,7 +243,7 @@ describe('Date & Time', () => {
     })
 
     it('should return Serial', () => {
-      useSerial();
+      useSerial()
       expect(dateTime.TODAY()).to.be.a('number')
     })
   })

--- a/test/utils/date.js
+++ b/test/utils/date.js
@@ -1,0 +1,35 @@
+import {expect} from "chai";
+import * as dateTime from "../../src/date-time.js";
+import * as dateUtils from "../../src/utils/date.js";
+import {useDate} from "../../src/utils/date.js";
+
+describe('Date & Time utils', () => {
+  beforeEach(() => {
+    useDate();
+  })
+
+  describe('FormulaJs default behavior', () => {
+    it('should return plain JS Date Object', () => {
+      expect(dateTime.DATEVALUE('1/1/1900')).to.deep.equal(new Date(1900, 0, 1))
+    });
+
+    it('should return serial number using a useSerial util switch', () => {
+      dateUtils.useSerial();
+
+      expect(dateTime.DATE(1900, 1, 1)).to.equal(1)
+      expect(dateTime.DATEVALUE('1/1/1900')).to.equal(1)
+    });
+  })
+
+  describe('dateToSerial ', () => {
+    it('should convert JS Date to Serial', () => {
+      expect(dateUtils.dateToSerial(new Date(1900, 0, 1))).to.equal(1)
+    })
+  })
+
+  describe('serialToDate ', () => {
+    it('should convert Serial to JS Date', () => {
+      expect(dateUtils.serialToDate(1)).to.deep.equal(new Date(1900, 0, 1))
+    })
+  })
+});

--- a/test/utils/date.js
+++ b/test/utils/date.js
@@ -1,24 +1,24 @@
-import {expect} from "chai";
-import * as dateTime from "../../src/date-time.js";
-import * as dateUtils from "../../src/utils/date.js";
-import {useDate} from "../../src/utils/date.js";
+import { expect } from 'chai'
+import * as dateTime from '../../src/date-time.js'
+import * as dateUtils from '../../src/utils/date.js'
+import { useDate } from '../../src/utils/date.js'
 
 describe('Date & Time utils', () => {
   beforeEach(() => {
-    useDate();
+    useDate()
   })
 
   describe('FormulaJs default behavior', () => {
     it('should return plain JS Date Object', () => {
       expect(dateTime.DATEVALUE('1/1/1900')).to.deep.equal(new Date(1900, 0, 1))
-    });
+    })
 
     it('should return serial number using a useSerial util switch', () => {
-      dateUtils.useSerial();
+      dateUtils.useSerial()
 
       expect(dateTime.DATE(1900, 1, 1)).to.equal(1)
       expect(dateTime.DATEVALUE('1/1/1900')).to.equal(1)
-    });
+    })
   })
 
   describe('dateToSerial ', () => {
@@ -32,4 +32,4 @@ describe('Date & Time utils', () => {
       expect(dateUtils.serialToDate(1)).to.deep.equal(new Date(1900, 0, 1))
     })
   })
-});
+})

--- a/test/utils/date.js
+++ b/test/utils/date.js
@@ -1,11 +1,10 @@
 import { expect } from 'chai'
 import * as dateTime from '../../src/date-time.js'
 import * as dateUtils from '../../src/utils/date.js'
-import { useDate } from '../../src/utils/date.js'
 
 describe('Date & Time utils', () => {
   beforeEach(() => {
-    useDate()
+    dateUtils.useDate()
   })
 
   describe('FormulaJs default behavior', () => {


### PR DESCRIPTION
Following discussions #13 and #24, with this PR:

- FormulaJs returns a JS Date by default (for backward compatibility).
- FormulaJs can switch to a serial number using formulajs.date.useSerial().
- FormulaJs can switch to a JS Date using formulajs.date.useDate().
- Two new utility functions have been added: formulajs.date.serialToDate and formulajs.date.dateToSerial.

Resolve also #75 
