### PR TITLE
IMSUM fixes

### DIFF
--- a/src/engineering.js
+++ b/src/engineering.js
@@ -1874,27 +1874,19 @@ export function IMSUM() {
 
   const args = utils.flatten(arguments)
 
-  // Initialize result
-  let result = args[0]
-
-  // Loop on all numbers
-  for (let i = 1; i < args.length; i++) {
-    // Lookup coefficients of two complex numbers
-    const a = IMREAL(result)
-    const b = IMAGINARY(result)
-    const c = IMREAL(args[i])
-    const d = IMAGINARY(args[i])
-
-    if (utils.anyIsError(a, b, c, d)) {
+  let numberSum = 0
+  let imaginarySum = 0
+  for (const arg of args) {
+    const realPart = +IMREAL(arg)
+    const imaginaryPart = +IMAGINARY(arg)
+    if (utils.anyIsError(realPart, imaginaryPart)) {
       return error.value
     }
-
-    // Complute product of two complex numbers
-    result = COMPLEX(a + c, b + d)
+    numberSum += realPart
+    imaginarySum += imaginaryPart
   }
 
-  // Return sum of complex numbers
-  return result
+  return COMPLEX(numberSum, imaginarySum, 'i')
 }
 
 /**

--- a/test/engineering.js
+++ b/test/engineering.js
@@ -427,6 +427,8 @@ describe('Engineering', () => {
   it('IMSUM', () => {
     expect(engineering.IMSUM('3+4i', '5-3i')).to.equal('8+i')
     expect(engineering.IMSUM('a', '5+3i')).to.equal(error.value)
+    expect(engineering.IMSUM(1, 2, 3)).to.equal('6')
+    expect(engineering.IMSUM(1, '2i', 3)).to.equal('4+2i')
     expect(engineering.IMSUM()).to.equal(error.value)
   })
 

--- a/test/engineering.js
+++ b/test/engineering.js
@@ -425,7 +425,9 @@ describe('Engineering', () => {
   })
 
   it('IMSUM', () => {
+    expect(engineering.IMSUM('3+6i', '5-2i')).to.equal('8+4i')
     expect(engineering.IMSUM('3+4i', '5-3i')).to.equal('8+i')
+    expect(engineering.IMSUM('25+100i', '33-2i', 100, '5i', 1, 2, 3, 1000, '1000i')).to.equal('1164+1103i')
     expect(engineering.IMSUM('a', '5+3i')).to.equal(error.value)
     expect(engineering.IMSUM(1, 2, 3)).to.equal('6')
     expect(engineering.IMSUM(1, '2i', 3)).to.equal('4+2i')


### PR DESCRIPTION
I noticed the IMSUM function was behaving odd:

|Expression|FormulaJS result|Google Spreadsheets result|
|--------------|-----------------|---------------------------|
|`IMSUM(1,2,3)`|123|6|
|`IMSUM(1, '2i', 3)`|103+2i|4+2i|

So I added test cases for these (+ some other ones) and rewrote the function to fix it. The tests are now passing (atleast the ones that run when I ran `npm run test`)